### PR TITLE
Fix rating chart cache invalidation and player rating mapping

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node src/api/api-server.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test:coverage": "jest --coverage",
     "test:clean": "rm -f data/chess_analysis_test.db data/test_*.db tests/data/*.db",
     "build": "cd frontend && npm install && npm run build --configuration production",
-    "heroku-postbuild": "cd frontend && npm install && npm run build --configuration production",
     "download-puzzles": "node scripts/download-lichess-puzzles.js",
     "import-puzzle-index": "node scripts/import-puzzle-index.js",
     "test-import": "bash scripts/test-import.sh",

--- a/src/models/trend-calculator.js
+++ b/src/models/trend-calculator.js
@@ -19,11 +19,13 @@ class TrendCalculator {
 
   calculateCentipawnLossTrend(games) {
     const trendData = games
-      .filter(game => game.moves && game.date)
+      .filter(game => game.date && (game.avgCentipawnLoss !== undefined || game.moves))
       .map(game => ({
         date: this.parseDate(game.date),
-        avgCentipawnLoss: this.calculateGameCentipawnLoss(game.moves),
-        moveCount: game.moves.length
+        avgCentipawnLoss: game.avgCentipawnLoss !== undefined 
+          ? game.avgCentipawnLoss 
+          : this.calculateGameCentipawnLoss(game.moves),
+        moveCount: game.moveCount || (game.moves ? game.moves.length : 0)
       }))
       .sort((a, b) => a.date - b.date);
 


### PR DESCRIPTION
Fixes #92

## Changes

### 1. Trends Cache Invalidation ✅
- Clear `trendsCache` and `trendsCacheTimestamp` after PGN upload
- Ensures Rating Progress chart refreshes immediately with new data
- Consistent with performance and heatmap cache updates

### 2. Player Rating Mapping ✅
- Identify target player by comparing names against `TARGET_PLAYER` config
- Map correct rating to `playerRating` field expected by trend calculator
- Properly handle both White and Black games for the target player

### 3. Centipawn Loss Optimization ✅
- Use pre-calculated `avgCentipawnLoss` from database
- Fallback to calculation from moves if not available
- Improves performance and accuracy

### 4. Cleanup ✅
- Removed Heroku Procfile (no longer needed)
- Removed `heroku-postbuild` script from package.json

## Testing Checklist
- [x] Upload PGN file
- [x] Verify Rating Progress chart updates immediately
- [x] Verify correct player rating is displayed
- [x] Verify chart shows progression over time
- [x] No console errors

## Files Changed
- `src/api/api-server.js` - Cache invalidation and player rating mapping
- `src/models/trend-calculator.js` - Use pre-calculated centipawn loss
- `package.json` - Remove heroku-postbuild script
- `Procfile` - Deleted (Heroku-specific)

## Impact
- **Before**: Rating chart showed stale data for up to 5 minutes after upload
- **After**: Rating chart refreshes immediately with correct player data