### PR TITLE
Fix centipawn chart Date parsing error

### DIFF
--- a/src/models/trend-calculator.js
+++ b/src/models/trend-calculator.js
@@ -52,6 +52,11 @@ class TrendCalculator {
   }
 
   parseDate(dateString) {
+    // If already a Date object, return it
+    if (dateString instanceof Date) {
+      return dateString;
+    }
+    
     // Handle PGN date format: "2023.01.15" or "2023.01.??"
     if (!dateString || dateString.includes('?')) {
       return new Date();


### PR DESCRIPTION
Fixes #94

## Problem

The centipawn loss chart fails to render because `parseDate()` expects strings but receives Date objects from the API, causing a TypeError when trying to call `.split()` on a Date object.

## Solution

Added type checking to handle both Date objects and date strings:

```javascript
parseDate(dateString) {
  // If already a Date object, return it
  if (dateString instanceof Date) {
    return dateString;
  }
  
  // Handle PGN date format: "2023.01.15" or "2023.01.??"
  if (!dateString || dateString.includes('?')) {
    return new Date();
  }
  
  const parts = dateString.split('.');
  // ... rest of string parsing
}
```

## Changes

- `src/models/trend-calculator.js` - Add `instanceof Date` check in `parseDate()`

## Impact

**Before:**
- Chart may fail to render with TypeError
- Shows "No centipawn data available" even when data exists
- JavaScript console errors

**After:**
- Chart renders correctly with real database data
- Handles both Date objects and date strings
- No errors in console

## Testing

- [x] Verified database contains centipawn loss data (4 games, avg ~27 CPL)
- [x] Confirmed API passes Date objects to trend calculator
- [x] Tested parseDate() handles both Date objects and strings
- [x] Chart displays correctly after fix

## Related

This fix complements PR #93 which added cache invalidation for the trends data.