### PR TITLE
Fix: Dashboard shows actual draw counts instead of zero (Issue #103)

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -389,10 +389,9 @@ export class DashboardComponent implements OnInit {
   }
 
   getWhiteDraws(): number {
-    // Calculate draws as remaining games after wins and losses
     if (!this.performanceData?.white) return 0;
-    // Based on actual data, there are no draws, so return 0
-    return 0;
+    // Use actual draw count from API response
+    return this.performanceData.white.draws || 0;
   }
 
   getBlackWins(): number {
@@ -408,10 +407,9 @@ export class DashboardComponent implements OnInit {
   }
 
   getBlackDraws(): number {
-    // Calculate draws as remaining games after wins and losses
     if (!this.performanceData?.black) return 0;
-    // Based on actual data, there are no draws, so return 0
-    return 0;
+    // Use actual draw count from API response
+    return this.performanceData.black.draws || 0;
   }
 
   // Dynamic insights based on actual data


### PR DESCRIPTION
## Description

Fixes #103 - Dashboard now displays actual draw counts instead of hardcoded zeros.

## Problem

The main dashboard (Performance by Color section) was showing **0 draws** for both White and Black, even when users had drawn games. The tournament listing page correctly showed the actual draw counts.

## Root Cause

The frontend dashboard component had hardcoded `return 0` in:
- `getWhiteDraws()` method (line 391-396)
- `getBlackDraws()` method (line 410-415)

Both methods had incorrect comments claiming 'there are no draws in actual data.'

However, the backend API was **correctly calculating and sending** draw counts in the response:
- `performanceData.white.draws`
- `performanceData.black.draws`

## Changes Made

✅ Updated `getWhiteDraws()` to return `this.performanceData.white.draws || 0`  
✅ Updated `getBlackDraws()` to return `this.performanceData.black.draws || 0`  
✅ Removed misleading comments  
✅ Rebuilt frontend with fix

## Files Changed

- `frontend/src/app/pages/dashboard/dashboard.component.ts` - Fixed draw count methods

## Testing

- [x] Draw counts now match between main dashboard and tournament listing
- [x] Win Rate subtitle correctly shows 'X wins, Y losses, Z draws'
- [x] Performance by Color section displays accurate draw statistics
- [x] Frontend rebuild successful

## Impact

**Before**: Dashboard showed 0 draws regardless of actual results  
**After**: Dashboard shows actual draw counts matching tournament listing

## Screenshots

The fix ensures consistency across:
1. Main dashboard 'Performance by Color' cards
2. Win Rate subtitle showing game distribution
3. Tournament listing page statistics

---

**Ready for review and merge**