### PR TITLE
feat: Chess.com Insights Dashboard (ADR 009 - Phases 1-3)

### DIFF
--- a/docs/adr/009-chesscom-insights-dashboard.md
+++ b/docs/adr/009-chesscom-insights-dashboard.md
@@ -304,13 +304,14 @@ Added to `dashboard.routes.js`:
 
 ### Phase 3: Frontend Dashboard Components - ✅ COMPLETE
 Created new `/insights` page with:
-- [x] Accuracy by Result card (wins/draws/losses breakdown)
-- [x] Phase Distribution card (where games typically end)
-- [x] Accuracy by Phase card (opening/middlegame/endgame)
-- [x] Opening Performance table with W/D/L progress bars (responsive: table on desktop, cards on mobile)
+- [x] Accuracy by Result card (wins/draws/losses breakdown) — **Issue #100 Image 1**
+- [x] Phase Distribution card (where games typically end) — **Issue #100 Image 2**
+- [x] Accuracy by Phase card (opening/middlegame/endgame) — **Issue #100 Image 3**
+- [x] Opening Performance table with W/D/L progress bars — **Issue #100 Image 4**
 - [x] Tactical Patterns card (reuses `/api/blunders/dashboard` data)
 - [x] Color filter (All/White/Black) for all insights
 - [x] Navigation link added to desktop and mobile layouts
+- [x] Responsive design (mobile card view for openings table)
 
 ### Phase 4: Minor Enhancements - Priority: LOW
 - [ ] Similar players comparison (requires rating-based grouping)
@@ -319,9 +320,19 @@ Created new `/insights` page with:
 - [ ] Export insights report
 
 ### Phase 5: Advanced Tactical Features - Priority: MEDIUM
-**These features require new backend infrastructure:**
+**These features require new backend infrastructure.**
+
+**Reference Screenshots from GitHub Issue #100:**
+- Images 5-6: Forks (found vs missed by piece type)
+- Images 7-8: Pins (found vs missed)
+- Image 9: Hanging Pieces (pieces you left hanging by type)
+- Image 10: Free Pieces (opponent's hanging pieces you found/missed)
+
+---
 
 #### 5.1 Found vs Missed Tactical Opportunities
+**Reference: Issue #100 Images 5-8 (Forks & Pins)**
+
 Track when player found or missed tactical patterns (forks, pins, skewers).
 
 **Current State:** We only track blunders (missed tactics by the player). We don't track:
@@ -378,6 +389,8 @@ CREATE INDEX idx_tactical_opp_found ON tactical_opportunities(was_found);
 ---
 
 #### 5.2 Hanging Pieces by Piece Type
+**Reference: Issue #100 Image 9 (Pieces you left hanging)**
+
 Track which piece types the player leaves hanging most often.
 
 **Current State:** We track `hanging_piece` as a tactical theme but don't store which piece was hanging.
@@ -408,6 +421,8 @@ ALTER TABLE blunder_details ADD COLUMN piece_type TEXT;
 ---
 
 #### 5.3 Free Pieces (Opponent Blunders)
+**Reference: Issue #100 Image 10 (Pieces your opponent left hanging)**
+
 Track pieces the opponent left hanging - did we capture them or miss the opportunity?
 
 **Current State:** We only analyze the player's moves, not opponent mistakes.

--- a/docs/adr/009-chesscom-insights-dashboard.md
+++ b/docs/adr/009-chesscom-insights-dashboard.md
@@ -1,0 +1,498 @@
+# ADR 009: Chess.com Insights Dashboard Features
+
+## Status
+Proposed
+
+## Context
+This ADR documents features from Chess.com's Insights dashboard (https://www.chess.com/insights) that should be considered for future implementation in our chess analysis platform. These features provide comprehensive game analysis and performance tracking that would enhance user experience.
+
+## Reference
+- GitHub Issue: [#100 - Review chess.com insights for future dashboard](https://github.com/toamitkumar/chess-analyzer/issues/100)
+- Chess.com Insights: https://www.chess.com/insights#phases
+- Labels: `dashboard`, `enhancement`, `epic:unified-dashboard`, `priority:medium`
+
+---
+
+## Current Implementation Status
+
+### What Already Exists (Infrastructure Ready)
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| **Database Schema** | 95% | Migration 002, 007 |
+| `phase_analysis` table | ✅ Ready | Stores per-game phase stats |
+| `phase_stats` table | ✅ Ready | Aggregated phase statistics |
+| `opening_analysis` table | ✅ Ready | ECO codes, opening names |
+| `opening_stats` table | ✅ Ready | Opening W/D/L rates (empty) |
+| `tactical_motifs` table | ✅ Ready | Fork, pin, hanging piece data |
+| `blunder_details` table | ✅ Ready | Phase, tactical_theme, severity |
+| **Backend Models** | | |
+| `tactical-detector.js` | ✅ Ready | Detects forks, pins, hanging pieces |
+| `opening-detector.js` | ✅ Ready | ECO code detection (40+ openings) |
+| `accuracy-calculator.js` | ⚠️ Partial | Overall only, not by phase/result |
+| **Backend Services** | | |
+| `BlunderService.js` | ✅ Ready | Blunder aggregation by phase/theme/severity |
+| **API Endpoints** | | |
+| `GET /api/games/:id/phases` | ✅ Ready | Per-game phase accuracy |
+| `GET /api/performance` | ✅ Ready | Overall performance by color |
+| `GET /api/blunders/dashboard` | ✅ Ready | **Tactical patterns by phase & theme** |
+| `GET /api/blunders/by-phase/:phase` | ✅ Ready | Blunders filtered by game phase |
+| `GET /api/blunders/by-theme/:theme` | ✅ Ready | Blunders filtered by tactical theme |
+| `GET /api/blunders/timeline` | ✅ Ready | Blunder trends over time |
+| **Frontend Components** | | |
+| `phase-analysis.component.ts` | ✅ Ready | Per-game phase visualization |
+
+### Existing Blunder Dashboard API (Critical Discovery)
+
+The `/api/blunders/dashboard` endpoint already provides comprehensive tactical pattern data:
+
+```javascript
+// GET /api/blunders/dashboard returns:
+{
+  overview: {
+    totalBlunders: number,
+    avgCentipawnLoss: number,
+    trend: { period, blunders, avgLoss }
+  },
+  byPhase: {
+    opening: { count, percentage, avgLoss },
+    middlegame: { count, percentage, avgLoss },
+    endgame: { count, percentage, avgLoss }
+  },
+  byTheme: [
+    { theme: 'hanging_piece', count, percentage, avgLoss },
+    { theme: 'fork', count, percentage, avgLoss },
+    { theme: 'pin', count, percentage, avgLoss },
+    // ... other tactical themes
+  ],
+  bySeverity: {
+    critical: { count, percentage },
+    major: { count, percentage },
+    moderate: { count, percentage },
+    minor: { count, percentage }
+  },
+  topPatterns: [
+    { theme, phase, count, percentage }
+  ],
+  learningProgress: {
+    learnedCount, unlearnedCount, percentage
+  }
+}
+```
+
+**This covers ~80% of the chess.com Tactical Patterns feature!**
+
+### What Needs to Be Built
+
+| Component | Status | Description |
+|-----------|--------|-------------|
+| **DashboardService Methods** | ⚠️ Partial | Add insights aggregation methods (some exist via BlunderService) |
+| **Accuracy by Result** | ❌ Missing | `getAccuracyByResult()` - Group by win/draw/loss |
+| **Aggregate Phase Stats** | ❌ Missing | `getPhaseDistribution()` - % games ending in each phase |
+| **Accuracy by Phase** | ⚠️ Partial | `getAccuracyByPhase()` - Cross-game phase accuracy (per-game exists) |
+| **Opening Performance** | ❌ Missing | `getOpeningPerformance()` - Top 10 openings W/D/L |
+| **Tactical Patterns** | ✅ Exists | **Already in `/api/blunders/dashboard`** - byPhase, byTheme |
+| **Hanging Pieces by Type** | ⚠️ Partial | Need to add `piece_type` breakdown (theme exists, piece type missing) |
+| **Dashboard Routes** | ⚠️ Partial | Add `/api/insights/*` routes (can reuse blunder routes) |
+| **Frontend Components** | ❌ Missing | Add insights cards/charts to dashboard page |
+
+### Reuse vs Build Decision
+
+| Chess.com Feature | Build New? | Notes |
+|-------------------|------------|-------|
+| Average Accuracy Overview | ✅ Build | Need `getAccuracyByResult()` |
+| Game Phases (where games end) | ✅ Build | Need `getPhaseDistribution()` |
+| Accuracy by Game Phase | ⚠️ Extend | Per-game exists, need aggregate |
+| Opening Performance | ✅ Build | `opening_stats` table ready but empty |
+| Forks/Pins (found vs missed) | 🔄 Reuse | `/api/blunders/dashboard` byTheme |
+| Hanging Pieces (your blunders) | 🔄 Reuse | `/api/blunders/dashboard` byTheme |
+| Free Pieces (opponent blunders) | ✅ Build | Need opponent blunder tracking |
+
+---
+
+## Chess.com Insights Feature Analysis
+
+### 1. Average Accuracy Overview
+**Description**: Displays overall accuracy percentage with breakdown by game outcome.
+
+**Components**:
+- Overall accuracy percentage (e.g., 75.13%)
+- Accuracy when you win
+- Accuracy when you draw
+- Accuracy when you lose
+
+**Implementation Notes**:
+- Calculate from existing centipawn loss data
+- Requires grouping games by result
+- Display as prominent header card
+
+---
+
+### 2. Game Phases Analysis
+**Description**: Shows which phase of the game (Opening, Middlegame, Endgame) your games typically end in.
+
+**Views**:
+1. **Overall**: Aggregate percentage for all games
+2. **By Piece Color**: Separate stats for White and Black
+3. **Similar Players**: Comparison with players of similar rating (future feature)
+
+**Data Structure**:
+```
+Phase        | Games | Percentage
+-------------|-------|------------
+Opening      |   0   |    0%
+Middlegame   |   0   |    0%
+Endgame      |   2   |  100%
+```
+
+**Phase Definitions**:
+- Opening: Moves 1-10 (approximately)
+- Middlegame: Moves 11-30
+- Endgame: Moves 31+
+
+**Implementation Notes**:
+- Track game length in moves
+- Determine which phase game ended based on move count
+- Consider piece count as alternative endgame detection
+
+---
+
+### 3. Accuracy by Game Phase
+**Description**: Bar chart visualization showing accuracy performance across game phases.
+
+**Data Points** (per phase):
+- Opening accuracy %
+- Middlegame accuracy %
+- Endgame accuracy %
+
+**Filters**:
+- When Playing White
+- When Playing Black
+- All games (combined)
+
+**Visualization**: Horizontal or vertical bar chart with labels showing exact percentages
+
+**Example Data**:
+```
+Phase       | White | Black
+------------|-------|-------
+Opening     | 84.0% | 82.5%
+Middlegame  | 80.8% | 73.4%
+Endgame     | 72.6% | 80.5%
+```
+
+---
+
+### 4. Opening Performance Analysis
+**Description**: Performance statistics for most frequently played openings.
+
+**Title**: "How well you perform in your 10 most played openings"
+
+**Data Columns**:
+- Opening Name (e.g., "Bird's Opening", "Slav Defense")
+- Moves (e.g., "1. f4", "1. d4 d5 2. c4 c6")
+- Total Games played
+- Win % (green)
+- Draw % (gray)
+- Loss % (red)
+
+**Filters**:
+- When Playing White
+- When Playing Black
+
+**Features**:
+- Clickable to drill down into specific opening games
+- Visual progress bar showing W/D/L distribution
+
+---
+
+### 5. Tactical Patterns Analysis
+
+#### 5.1 Forks
+**Description**: Track found vs missed fork opportunities by piece type.
+
+**Piece Categories**:
+- Pawn forks
+- Knight forks
+- Bishop forks
+- Rook forks
+- Queen forks
+- King forks (discovered attacks)
+
+**Metrics**:
+- Found count & percentage
+- Missed count & percentage
+- Total opportunities
+
+**Comparison Options**:
+- None (raw data)
+- Similar Players
+- Past Performance (trend over time)
+
+---
+
+#### 5.2 Pins
+**Description**: Track found vs missed pin opportunities.
+
+**Piece Categories**:
+- Bishop pins
+- Rook pins
+- Queen pins
+
+**Metrics**: Same as Forks
+
+---
+
+#### 5.3 Hanging Pieces (Blunders)
+**Description**: Track pieces left undefended that were captured.
+
+**Title**: "Pieces you left hanging"
+
+**Piece Categories**:
+- Pawn
+- Knight
+- Bishop
+- Rook
+- Queen
+
+**Metrics**:
+- Count of hanging pieces by type
+- Percentage (relative frequency)
+- Visual indicator (red for problematic patterns)
+
+**Features**:
+- Clickable to review specific positions
+- Pattern identification for improvement areas
+
+---
+
+#### 5.4 Free Pieces (Opponent Blunders)
+**Description**: Track opponent's hanging pieces that you found vs missed.
+
+**Title**: "Pieces your opponent left hanging"
+
+**Piece Categories**: Same as Hanging Pieces
+
+**Metrics**:
+- Found: Count & percentage of captured hanging pieces
+- Missed: Count & percentage of opportunities not taken
+
+---
+
+## Implementation Phases
+
+### Phase 1: Extend DashboardService (Backend) - Priority: HIGH
+- [x] Track game phase where game ended (Migration 002 - `phase_stats` table)
+- [x] Calculate accuracy per game phase (per-game: `/api/games/:id/phases`)
+- [x] Track opening statistics schema (`opening_stats` table exists)
+- [x] Store tactical pattern data (`tactical_motifs`, `blunder_details` tables)
+- [x] **DONE**: Tactical patterns by phase & theme (`/api/blunders/dashboard`)
+- [x] **DONE**: Blunders by phase (`/api/blunders/by-phase/:phase`)
+- [x] **DONE**: Blunders by theme (`/api/blunders/by-theme/:theme`)
+- [ ] **NEW**: Add `getAccuracyByResult()` method to `DashboardService.js`
+- [ ] **NEW**: Add `getPhaseDistribution()` method to `DashboardService.js`
+- [ ] **NEW**: Add `getAccuracyByPhase()` method to `DashboardService.js` (aggregate cross-game)
+- [ ] **NEW**: Add `getOpeningPerformance()` method to `DashboardService.js`
+
+### Phase 2: Add API Endpoints to Dashboard Routes - Priority: HIGH
+Add to `dashboard.routes.js`:
+- [ ] `GET /api/insights/accuracy` - Accuracy by result (win/draw/loss)
+- [ ] `GET /api/insights/phases` - Aggregate phase distribution (% games ending in each phase)
+- [ ] `GET /api/insights/accuracy-by-phase` - Average accuracy per phase across all games
+- [ ] `GET /api/insights/openings` - Top 10 openings with W/D/L stats
+- [x] ~~`GET /api/insights/tactics/summary`~~ - **Use `/api/blunders/dashboard` instead**
+- [ ] `GET /api/insights/tactics/hanging-by-piece` - Hanging pieces grouped by piece type (optional enhancement)
+
+### Phase 3: Frontend Dashboard Components - Priority: MEDIUM
+Add to existing dashboard page:
+- [ ] Accuracy by result card (chess.com style green gradient)
+- [ ] Game phases distribution chart (bar/pie)
+- [ ] Accuracy by phase chart (filterable by color)
+- [ ] Opening performance table with W/D/L progress bars
+- [ ] Tactical patterns card (**Reuse data from `/api/blunders/dashboard`**)
+
+### Phase 4: Advanced Features - Priority: LOW
+- [ ] Similar players comparison (requires rating-based grouping)
+- [ ] Past performance trends (time-series data) - **Partial: `/api/blunders/timeline` exists**
+- [ ] Drill-down to specific games/positions
+- [ ] Export insights report
+- [ ] Opponent blunder tracking (free pieces you missed)
+
+## Database Schema Status
+
+### Existing Tables (Migration 002 & 007) - NO NEW MIGRATIONS NEEDED
+
+```sql
+-- Already exists: phase_analysis (per-move phase data)
+-- Already exists: phase_stats (per-game phase aggregates)
+CREATE TABLE phase_stats (
+  id INTEGER PRIMARY KEY,
+  game_id INTEGER REFERENCES games(id),
+  opening_accuracy REAL,
+  middlegame_accuracy REAL,
+  endgame_accuracy REAL,
+  opening_blunders INTEGER,
+  middlegame_blunders INTEGER,
+  endgame_blunders INTEGER
+);
+
+-- Already exists: opening_stats (opening performance)
+CREATE TABLE opening_stats (
+  id INTEGER PRIMARY KEY,
+  user_id TEXT,
+  opening_name TEXT,
+  eco_code TEXT,
+  player_color TEXT, -- 'white' or 'black'
+  games_played INTEGER,
+  wins INTEGER,
+  draws INTEGER,
+  losses INTEGER,
+  avg_accuracy REAL
+);
+
+-- Already exists: tactical_motifs (tactical patterns)
+CREATE TABLE tactical_motifs (
+  id INTEGER PRIMARY KEY,
+  game_id INTEGER REFERENCES games(id),
+  move_number INTEGER,
+  motif_type TEXT, -- 'fork', 'pin', 'skewer', 'discovered_attack', etc.
+  piece_involved TEXT,
+  difficulty TEXT,
+  squares TEXT
+);
+
+-- Already exists: blunder_details (enhanced blunder tracking)
+CREATE TABLE blunder_details (
+  id INTEGER PRIMARY KEY,
+  game_id INTEGER REFERENCES games(id),
+  move_number INTEGER,
+  phase TEXT, -- 'opening', 'middlegame', 'endgame'
+  tactical_theme TEXT, -- 'hanging_piece', 'fork', 'pin', etc.
+  player_color TEXT,
+  severity TEXT,
+  eval_before REAL,
+  eval_after REAL,
+  centipawn_loss INTEGER,
+  win_probability_before REAL,
+  win_probability_after REAL,
+  fen_before TEXT
+);
+```
+
+### Data Population Required
+The tables exist but may be empty. Need to:
+1. Run backfill job to populate `opening_stats` from existing games
+2. Ensure `phase_stats` is populated during game analysis
+3. Ensure `blunder_details` captures tactical themes
+
+## UI/UX Considerations
+
+### Color Scheme (Chess.com Style)
+- Background: Green gradient (#769656 to #baca44)
+- Cards: Semi-transparent white overlay
+- Win: Green (#22c55e)
+- Draw: Gray (#6b7280)
+- Loss: Red (#ef4444)
+- Found/Success: Green with checkmark
+- Missed/Problem: Red with X
+
+### Layout
+- Card-based design with rounded corners
+- Tabs for switching between views (Overall, By Piece Color, etc.)
+- Responsive grid layout
+- Interactive tooltips with additional details
+
+## Acceptance Criteria
+- [ ] User can view overall accuracy with breakdown by game result
+- [ ] User can see which game phase their games typically end in
+- [ ] User can view accuracy breakdown by game phase
+- [ ] User can see performance in their most played openings (top 10)
+- [ ] User can view tactical pattern statistics (forks, pins, hanging pieces)
+- [ ] All metrics can be filtered by piece color (White/Black)
+- [ ] Data is calculated from existing game analysis
+
+## Files to Create/Modify
+
+### Existing Dashboard Infrastructure (Add Insights Here)
+
+The insights APIs should be added to the **existing dashboard controller/service** rather than creating new files:
+
+**Current Dashboard Endpoints:**
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/performance` | GET | Performance metrics by color |
+| `/api/player-performance` | GET | Overall player performance |
+| `/api/trends` | GET | Weekly performance trends |
+| `/api/trends/rating` | GET | Rating progression |
+| `/api/trends/centipawn-loss` | GET | Centipawn loss trends |
+| `/api/heatmap-db` | GET | Blunder heatmap |
+| `/api/games` | GET | Games list with openings |
+
+**New Endpoints to Add:**
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/insights/accuracy` | GET | Accuracy breakdown by game result (win/draw/loss) |
+| `/api/insights/phases` | GET | Aggregate phase distribution (% games ending in each phase) |
+| `/api/insights/accuracy-by-phase` | GET | Average accuracy per phase across all games |
+| `/api/insights/openings` | GET | Top 10 openings with W/D/L stats |
+| `/api/insights/tactics/summary` | GET | Tactical patterns overview |
+| `/api/insights/tactics/hanging` | GET | Hanging pieces by piece type |
+
+### Files to Modify
+
+| File | Changes Needed |
+|------|----------------|
+| `src/services/DashboardService.js` | Add insights aggregation methods |
+| `src/api/controllers/dashboard.controller.js` | Add insights endpoint handlers |
+| `src/api/routes/dashboard.routes.js` | Register new `/insights/*` routes |
+| `src/models/accuracy-calculator.js` | Add `calculateByResult()` method |
+| `frontend/src/app/services/chess-api.service.ts` | Add insights API calls |
+| `frontend/src/app/pages/dashboard/` | Add insights charts/cards |
+
+### Files to Reference (No Changes Needed)
+
+| File | What It Provides |
+|------|------------------|
+| `src/models/tactical-detector.js` | Fork, pin, hanging piece detection |
+| `src/models/opening-detector.js` | ECO code and opening classification |
+| `src/api/controllers/game.controller.js` | `getPhases()` implementation pattern |
+| `frontend/src/app/pages/game-detail-v2/components/phase-analysis.component.ts` | Phase visualization reference |
+| **`src/services/BlunderService.js`** | **Blunder aggregation: byPhase, byTheme, bySeverity, timeline** |
+| **`src/api/controllers/blunder.controller.js`** | **`getDashboard()` - tactical patterns API pattern** |
+| **`src/api/routes/blunder.routes.js`** | **Existing `/api/blunders/*` routes for tactical data** |
+
+## Dependencies
+- ✅ Existing game analysis data (in `game_analysis` table)
+- ✅ Stockfish evaluation data (already captured)
+- ✅ Opening classification (`chess_openings` table + `opening-detector.js`)
+- ✅ Phase definitions (already implemented: opening 1-10, middlegame 11-30, endgame 31+)
+- ✅ Blunder tracking with phase/theme (`blunder_details` table)
+
+## Notes
+- **No new database migrations required** - all tables exist in Migration 002 & 007
+- Tables may need backfill/population from existing game data
+- ~~Tactical pattern detection exists but aggregation layer is missing~~ **RESOLVED: `/api/blunders/dashboard` provides full aggregation**
+- **IMPORTANT**: The blunder dashboard API (`/api/blunders/dashboard`) already provides tactical patterns breakdown by phase and theme - frontend can consume this directly
+- "Similar Players" feature requires user rating system (future)
+- Consider Redis caching for insights data (computationally expensive)
+
+## Effort Estimate
+
+**Revised estimate after discovering existing blunder infrastructure:**
+
+| Phase | Original | Revised | Notes |
+|-------|----------|---------|-------|
+| Phase 1: Aggregation Service | 2-3 days | **1-2 days** | Tactical patterns already exist |
+| Phase 2: API Endpoints | 1-2 days | **1 day** | Only 4 new endpoints needed |
+| Phase 3: Frontend Dashboard | 3-4 days | **2-3 days** | Can reuse blunder dashboard patterns |
+| Phase 4: Advanced Features | 2-3 days | 2-3 days | No change |
+| **Total** | **8-12 days** | **6-9 days** | ~25% reduction |
+
+**Key Savings:**
+- Tactical patterns API: Already implemented (`/api/blunders/dashboard`)
+- Blunders by phase/theme: Already implemented
+- Timeline trends: Already implemented (`/api/blunders/timeline`)
+
+## Related ADRs
+- ADR 007: Lichess Game Detail Layout
+- Future: ADR for rating system and player comparisons

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -60,6 +60,11 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/blunders/blunders.component').then(m => m.BlundersComponent),
     canActivate: [authGuard]
   },
+  {
+    path: 'insights',
+    loadComponent: () => import('./pages/insights/insights.component').then(m => m.InsightsComponent),
+    canActivate: [authGuard]
+  },
 
   // 404 page
   {

--- a/frontend/src/app/components/layout/layout.component.ts
+++ b/frontend/src/app/components/layout/layout.component.ts
@@ -64,6 +64,15 @@ import { AuthService } from '../../services/auth.service';
                 </svg>
                 Blunders
               </a>
+              <a routerLink="/insights"
+                 routerLinkActive="bg-accent/10 text-accent border-accent/50 shadow-glow-accent"
+                 class="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 text-muted-foreground hover:bg-accent/5 hover:text-accent hover:border-accent/30 border border-transparent">
+                <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21.21 15.89A10 10 0 1 1 8 2.83"/>
+                  <path d="M22 12A10 10 0 0 0 12 2v10z"/>
+                </svg>
+                Insights
+              </a>
 
               <!-- User Menu -->
               @if (authService.isAuthenticated()) {
@@ -109,7 +118,7 @@ import { AuthService } from '../../services/auth.service';
 
       <!-- Mobile Bottom Navigation -->
       <nav class="md:hidden fixed bottom-0 left-0 right-0 z-50 border-t-2 border-border/30 bg-card/95 backdrop-blur-lg shadow-2xl">
-        <div class="grid grid-cols-5 h-16">
+        <div class="grid grid-cols-6 h-16">
           <a routerLink="/"
              routerLinkActive="text-primary bg-primary/10"
              [routerLinkActiveOptions]="{exact: true}"
@@ -155,6 +164,16 @@ import { AuthService } from '../../services/auth.service';
               <line x1="12" y1="17" x2="12.01" y2="17"/>
             </svg>
             <span class="text-xs font-medium">Blunders</span>
+          </a>
+
+          <a routerLink="/insights"
+             routerLinkActive="text-accent bg-accent/10"
+             class="flex flex-col items-center justify-center gap-1 text-muted-foreground hover:text-accent transition-all duration-300 active:scale-95">
+            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21.21 15.89A10 10 0 1 1 8 2.83"/>
+              <path d="M22 12A10 10 0 0 0 12 2v10z"/>
+            </svg>
+            <span class="text-xs font-medium">Insights</span>
           </a>
 
           <!-- User Menu / Sign In -->

--- a/frontend/src/app/pages/insights/insights.component.ts
+++ b/frontend/src/app/pages/insights/insights.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterModule } from '@angular/router';
 import { LayoutComponent } from '../../components/layout/layout.component';
 import {
   ChessApiService,
@@ -11,36 +12,60 @@ import {
 } from '../../services/chess-api.service';
 import { forkJoin } from 'rxjs';
 
+interface BlunderDashboardData {
+  overview: {
+    totalBlunders: number;
+    avgCentipawnLoss: number;
+  };
+  byPhase: {
+    opening: { count: number; percentage: string; avgLoss: number };
+    middlegame: { count: number; percentage: string; avgLoss: number };
+    endgame: { count: number; percentage: string; avgLoss: number };
+  };
+  byTheme: Array<{
+    theme: string;
+    count: number;
+    percentage: string;
+    avgLoss: number;
+  }>;
+  bySeverity: {
+    critical: number;
+    major: number;
+    moderate: number;
+    minor: number;
+  };
+}
+
 @Component({
   selector: 'app-insights',
   standalone: true,
-  imports: [CommonModule, HttpClientModule, LayoutComponent],
+  imports: [CommonModule, HttpClientModule, RouterModule, LayoutComponent],
   template: `
     <app-layout>
-      <div class="space-y-8 pb-8">
+      <div class="space-y-6 sm:space-y-8 pb-8">
         <!-- Header Section -->
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 animate-fade-in">
+        <div class="flex flex-col gap-4 animate-fade-in">
           <div>
-            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-gradient tracking-tight mb-2">Chess Insights</h1>
+            <h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold text-gradient tracking-tight mb-2">Chess Insights</h1>
             <p class="text-sm sm:text-base text-muted-foreground">Deep analysis of your playing patterns and performance</p>
           </div>
 
           <!-- Color Filter -->
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button
               (click)="setColorFilter(null)"
-              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 ' + (colorFilter === null ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              [class]="'px-3 sm:px-4 py-2 rounded-lg text-sm font-medium transition-all duration-300 ' + (colorFilter === null ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
               All
             </button>
             <button
               (click)="setColorFilter('white')"
-              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'white' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              [class]="'px-3 sm:px-4 py-2 rounded-lg text-sm font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'white' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
               <div class="w-3 h-3 rounded-full bg-gradient-to-br from-gray-100 to-gray-300 border border-gray-400"></div>
               White
             </button>
             <button
               (click)="setColorFilter('black')"
-              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'black' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              [class]="'px-3 sm:px-4 py-2 rounded-lg text-sm font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'black' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
               <div class="w-3 h-3 rounded-full bg-gradient-to-br from-gray-700 to-gray-900"></div>
               Black
             </button>
@@ -48,88 +73,88 @@ import { forkJoin } from 'rxjs';
         </div>
 
         <!-- Loading State -->
-        <div *ngIf="loading" class="flex flex-col justify-center items-center py-16 animate-fade-in">
+        <div *ngIf="loading" class="flex flex-col justify-center items-center py-12 sm:py-16 animate-fade-in">
           <div class="relative">
-            <div class="w-16 h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></div>
-            <div class="absolute inset-0 w-16 h-16 border-4 border-transparent border-t-accent rounded-full animate-spin" style="animation-duration: 1.5s;"></div>
+            <div class="w-12 h-12 sm:w-16 sm:h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></div>
+            <div class="absolute inset-0 w-12 h-12 sm:w-16 sm:h-16 border-4 border-transparent border-t-accent rounded-full animate-spin" style="animation-duration: 1.5s;"></div>
           </div>
           <p class="text-muted-foreground mt-6 text-sm font-medium">Loading insights...</p>
         </div>
 
         <!-- Error State -->
-        <div *ngIf="error" class="rounded-2xl border-2 border-destructive/30 bg-gradient-to-br from-destructive/10 to-destructive/5 p-6 shadow-xl animate-slide-up">
-          <div class="flex items-start gap-4">
+        <div *ngIf="error" class="rounded-xl sm:rounded-2xl border-2 border-destructive/30 bg-gradient-to-br from-destructive/10 to-destructive/5 p-4 sm:p-6 shadow-xl animate-slide-up">
+          <div class="flex items-start gap-3 sm:gap-4">
             <div class="flex-shrink-0 p-2 rounded-lg bg-destructive/20">
-              <svg class="w-6 h-6 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 sm:w-6 sm:h-6 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
               </svg>
             </div>
             <div>
-              <h3 class="text-lg font-bold text-destructive mb-1">Error Loading Insights</h3>
+              <h3 class="text-base sm:text-lg font-bold text-destructive mb-1">Error Loading Insights</h3>
               <p class="text-sm text-foreground/80">{{ error }}</p>
             </div>
           </div>
         </div>
 
         <!-- Insights Grid -->
-        <div *ngIf="!loading && !error" class="grid gap-6 lg:grid-cols-2 animate-slide-up">
+        <div *ngIf="!loading && !error" class="grid gap-4 sm:gap-6 md:grid-cols-2 animate-slide-up">
 
           <!-- Accuracy by Result Card -->
-          <div *ngIf="accuracyByResult" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-success hover:border-success/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
-            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-success/5 to-transparent">
+          <div *ngIf="accuracyByResult" class="group rounded-xl sm:rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-xl sm:shadow-2xl hover:shadow-glow-success hover:border-success/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-4 sm:p-6 bg-gradient-to-br from-success/5 to-transparent">
               <div class="flex items-center gap-3">
                 <div class="p-2 rounded-lg bg-success/10 group-hover:bg-success/20 transition-colors duration-300">
-                  <svg class="w-5 h-5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-4 h-4 sm:w-5 sm:h-5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
                   </svg>
                 </div>
                 <div>
-                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Result</h3>
-                  <p class="text-sm text-muted-foreground mt-1">How accurately you play in wins vs losses</p>
+                  <h3 class="text-lg sm:text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Result</h3>
+                  <p class="text-xs sm:text-sm text-muted-foreground mt-1">How accurately you play in wins vs losses</p>
                 </div>
               </div>
             </div>
-            <div class="p-6 pt-2">
-              <div class="space-y-4">
+            <div class="p-4 sm:p-6 pt-2">
+              <div class="space-y-3 sm:space-y-4">
                 <!-- Overall -->
-                <div class="flex items-center justify-between p-3 rounded-lg bg-card/50 border border-border/30">
-                  <span class="font-medium text-foreground">Overall</span>
+                <div class="flex items-center justify-between p-2 sm:p-3 rounded-lg bg-card/50 border border-border/30">
+                  <span class="font-medium text-sm sm:text-base text-foreground">Overall</span>
                   <div class="text-right">
-                    <span class="text-2xl font-bold text-gradient">{{ accuracyByResult.overall.accuracy | number:'1.1-1' }}%</span>
-                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.overall.games }} games)</span>
+                    <span class="text-xl sm:text-2xl font-bold text-gradient">{{ accuracyByResult.overall.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-1 sm:ml-2">({{ accuracyByResult.overall.games }})</span>
                   </div>
                 </div>
                 <!-- Wins -->
-                <div class="flex items-center justify-between p-3 rounded-lg bg-success/5 border border-success/20">
+                <div class="flex items-center justify-between p-2 sm:p-3 rounded-lg bg-success/5 border border-success/20">
                   <div class="flex items-center gap-2">
                     <div class="w-2 h-2 rounded-full bg-success"></div>
-                    <span class="font-medium text-success">Wins</span>
+                    <span class="font-medium text-sm sm:text-base text-success">Wins</span>
                   </div>
                   <div class="text-right">
-                    <span class="text-xl font-bold text-success">{{ accuracyByResult.wins.accuracy | number:'1.1-1' }}%</span>
-                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.wins.games }} games)</span>
+                    <span class="text-lg sm:text-xl font-bold text-success">{{ accuracyByResult.wins.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-1 sm:ml-2">({{ accuracyByResult.wins.games }})</span>
                   </div>
                 </div>
                 <!-- Draws -->
-                <div class="flex items-center justify-between p-3 rounded-lg bg-muted/30 border border-border/30">
+                <div class="flex items-center justify-between p-2 sm:p-3 rounded-lg bg-muted/30 border border-border/30">
                   <div class="flex items-center gap-2">
                     <div class="w-2 h-2 rounded-full bg-muted-foreground"></div>
-                    <span class="font-medium text-muted-foreground">Draws</span>
+                    <span class="font-medium text-sm sm:text-base text-muted-foreground">Draws</span>
                   </div>
                   <div class="text-right">
-                    <span class="text-xl font-bold">{{ accuracyByResult.draws.accuracy | number:'1.1-1' }}%</span>
-                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.draws.games }} games)</span>
+                    <span class="text-lg sm:text-xl font-bold">{{ accuracyByResult.draws.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-1 sm:ml-2">({{ accuracyByResult.draws.games }})</span>
                   </div>
                 </div>
                 <!-- Losses -->
-                <div class="flex items-center justify-between p-3 rounded-lg bg-destructive/5 border border-destructive/20">
+                <div class="flex items-center justify-between p-2 sm:p-3 rounded-lg bg-destructive/5 border border-destructive/20">
                   <div class="flex items-center gap-2">
                     <div class="w-2 h-2 rounded-full bg-destructive"></div>
-                    <span class="font-medium text-destructive">Losses</span>
+                    <span class="font-medium text-sm sm:text-base text-destructive">Losses</span>
                   </div>
                   <div class="text-right">
-                    <span class="text-xl font-bold text-destructive">{{ accuracyByResult.losses.accuracy | number:'1.1-1' }}%</span>
-                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.losses.games }} games)</span>
+                    <span class="text-lg sm:text-xl font-bold text-destructive">{{ accuracyByResult.losses.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-1 sm:ml-2">({{ accuracyByResult.losses.games }})</span>
                   </div>
                 </div>
               </div>
@@ -137,94 +162,94 @@ import { forkJoin } from 'rxjs';
           </div>
 
           <!-- Accuracy by Phase Card -->
-          <div *ngIf="accuracyByPhase" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-accent hover:border-accent/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
-            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-accent/5 to-transparent">
+          <div *ngIf="accuracyByPhase" class="group rounded-xl sm:rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-xl sm:shadow-2xl hover:shadow-glow-accent hover:border-accent/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-4 sm:p-6 bg-gradient-to-br from-accent/5 to-transparent">
               <div class="flex items-center gap-3">
                 <div class="p-2 rounded-lg bg-accent/10 group-hover:bg-accent/20 transition-colors duration-300">
-                  <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-4 h-4 sm:w-5 sm:h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                   </svg>
                 </div>
                 <div>
-                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Phase</h3>
-                  <p class="text-sm text-muted-foreground mt-1">Your accuracy in different game phases</p>
+                  <h3 class="text-lg sm:text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Phase</h3>
+                  <p class="text-xs sm:text-sm text-muted-foreground mt-1">Your accuracy in different game phases</p>
                 </div>
               </div>
             </div>
-            <div class="p-6 pt-2">
-              <div class="space-y-4">
+            <div class="p-4 sm:p-6 pt-2">
+              <div class="space-y-3 sm:space-y-4">
                 <!-- Opening -->
                 <div class="space-y-2">
                   <div class="flex items-center justify-between">
-                    <span class="font-medium text-foreground">Opening</span>
-                    <span class="text-lg font-bold text-chart-1">{{ accuracyByPhase.opening.accuracy | number:'1.1-1' }}%</span>
+                    <span class="font-medium text-sm sm:text-base text-foreground">Opening</span>
+                    <span class="text-base sm:text-lg font-bold text-chart-1">{{ accuracyByPhase.opening.accuracy | number:'1.1-1' }}%</span>
                   </div>
-                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                  <div class="relative h-2 sm:h-3 w-full overflow-hidden rounded-full bg-muted/50">
                     <div class="h-full bg-gradient-to-r from-chart-1 to-chart-1/80 rounded-full transition-all duration-1000"
                       [style.width.%]="accuracyByPhase.opening.accuracy"></div>
                   </div>
-                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.opening.gamesWithData }} games with data</p>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.opening.gamesWithData }} games</p>
                 </div>
                 <!-- Middlegame -->
                 <div class="space-y-2">
                   <div class="flex items-center justify-between">
-                    <span class="font-medium text-foreground">Middlegame</span>
-                    <span class="text-lg font-bold text-chart-2">{{ accuracyByPhase.middlegame.accuracy | number:'1.1-1' }}%</span>
+                    <span class="font-medium text-sm sm:text-base text-foreground">Middlegame</span>
+                    <span class="text-base sm:text-lg font-bold text-chart-2">{{ accuracyByPhase.middlegame.accuracy | number:'1.1-1' }}%</span>
                   </div>
-                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                  <div class="relative h-2 sm:h-3 w-full overflow-hidden rounded-full bg-muted/50">
                     <div class="h-full bg-gradient-to-r from-chart-2 to-chart-2/80 rounded-full transition-all duration-1000"
                       [style.width.%]="accuracyByPhase.middlegame.accuracy"></div>
                   </div>
-                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.middlegame.gamesWithData }} games with data</p>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.middlegame.gamesWithData }} games</p>
                 </div>
                 <!-- Endgame -->
                 <div class="space-y-2">
                   <div class="flex items-center justify-between">
-                    <span class="font-medium text-foreground">Endgame</span>
-                    <span class="text-lg font-bold text-chart-3">{{ accuracyByPhase.endgame.accuracy | number:'1.1-1' }}%</span>
+                    <span class="font-medium text-sm sm:text-base text-foreground">Endgame</span>
+                    <span class="text-base sm:text-lg font-bold text-chart-3">{{ accuracyByPhase.endgame.accuracy | number:'1.1-1' }}%</span>
                   </div>
-                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                  <div class="relative h-2 sm:h-3 w-full overflow-hidden rounded-full bg-muted/50">
                     <div class="h-full bg-gradient-to-r from-chart-3 to-chart-3/80 rounded-full transition-all duration-1000"
                       [style.width.%]="accuracyByPhase.endgame.accuracy"></div>
                   </div>
-                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.endgame.gamesWithData }} games with data</p>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.endgame.gamesWithData }} games</p>
                 </div>
               </div>
             </div>
           </div>
 
           <!-- Phase Distribution Card -->
-          <div *ngIf="phaseDistribution" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-primary hover:border-primary/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
-            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-primary/5 to-transparent">
+          <div *ngIf="phaseDistribution" class="group rounded-xl sm:rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-xl sm:shadow-2xl hover:shadow-glow-primary hover:border-primary/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-4 sm:p-6 bg-gradient-to-br from-primary/5 to-transparent">
               <div class="flex items-center gap-3">
                 <div class="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors duration-300">
-                  <svg class="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-4 h-4 sm:w-5 sm:h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
                   </svg>
                 </div>
                 <div>
-                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Phase Distribution</h3>
-                  <p class="text-sm text-muted-foreground mt-1">When do your games typically end?</p>
+                  <h3 class="text-lg sm:text-xl font-bold leading-none tracking-tight text-gradient">Phase Distribution</h3>
+                  <p class="text-xs sm:text-sm text-muted-foreground mt-1">When do your games typically end?</p>
                 </div>
               </div>
             </div>
-            <div class="p-6 pt-2">
-              <div class="space-y-4">
-                <p class="text-sm text-muted-foreground text-center mb-4">{{ phaseDistribution.totalGames }} games analyzed</p>
+            <div class="p-4 sm:p-6 pt-2">
+              <div class="space-y-3 sm:space-y-4">
+                <p class="text-xs sm:text-sm text-muted-foreground text-center mb-2 sm:mb-4">{{ phaseDistribution.totalGames }} games analyzed</p>
 
                 <!-- Horizontal Bar Chart -->
                 <div class="space-y-3">
                   <!-- Opening -->
                   <div class="space-y-1">
-                    <div class="flex items-center justify-between text-sm">
+                    <div class="flex items-center justify-between text-xs sm:text-sm">
                       <span class="font-medium">Opening</span>
                       <span class="text-muted-foreground">{{ phaseDistribution.overall.opening.count }} ({{ phaseDistribution.overall.opening.percentage | number:'1.0-0' }}%)</span>
                     </div>
-                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                    <div class="relative h-5 sm:h-6 w-full overflow-hidden rounded-lg bg-muted/30">
                       <div class="h-full bg-gradient-to-r from-chart-1 to-chart-1/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
-                        [style.width.%]="phaseDistribution.overall.opening.percentage">
-                        <span *ngIf="phaseDistribution.overall.opening.percentage > 10" class="text-xs font-bold text-white">
+                        [style.width.%]="phaseDistribution.overall.opening.percentage || 1">
+                        <span *ngIf="phaseDistribution.overall.opening.percentage > 15" class="text-xs font-bold text-white">
                           {{ phaseDistribution.overall.opening.percentage | number:'1.0-0' }}%
                         </span>
                       </div>
@@ -232,14 +257,14 @@ import { forkJoin } from 'rxjs';
                   </div>
                   <!-- Middlegame -->
                   <div class="space-y-1">
-                    <div class="flex items-center justify-between text-sm">
+                    <div class="flex items-center justify-between text-xs sm:text-sm">
                       <span class="font-medium">Middlegame</span>
                       <span class="text-muted-foreground">{{ phaseDistribution.overall.middlegame.count }} ({{ phaseDistribution.overall.middlegame.percentage | number:'1.0-0' }}%)</span>
                     </div>
-                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                    <div class="relative h-5 sm:h-6 w-full overflow-hidden rounded-lg bg-muted/30">
                       <div class="h-full bg-gradient-to-r from-chart-2 to-chart-2/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
-                        [style.width.%]="phaseDistribution.overall.middlegame.percentage">
-                        <span *ngIf="phaseDistribution.overall.middlegame.percentage > 10" class="text-xs font-bold text-white">
+                        [style.width.%]="phaseDistribution.overall.middlegame.percentage || 1">
+                        <span *ngIf="phaseDistribution.overall.middlegame.percentage > 15" class="text-xs font-bold text-white">
                           {{ phaseDistribution.overall.middlegame.percentage | number:'1.0-0' }}%
                         </span>
                       </div>
@@ -247,14 +272,14 @@ import { forkJoin } from 'rxjs';
                   </div>
                   <!-- Endgame -->
                   <div class="space-y-1">
-                    <div class="flex items-center justify-between text-sm">
+                    <div class="flex items-center justify-between text-xs sm:text-sm">
                       <span class="font-medium">Endgame</span>
                       <span class="text-muted-foreground">{{ phaseDistribution.overall.endgame.count }} ({{ phaseDistribution.overall.endgame.percentage | number:'1.0-0' }}%)</span>
                     </div>
-                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                    <div class="relative h-5 sm:h-6 w-full overflow-hidden rounded-lg bg-muted/30">
                       <div class="h-full bg-gradient-to-r from-chart-3 to-chart-3/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
-                        [style.width.%]="phaseDistribution.overall.endgame.percentage">
-                        <span *ngIf="phaseDistribution.overall.endgame.percentage > 10" class="text-xs font-bold text-white">
+                        [style.width.%]="phaseDistribution.overall.endgame.percentage || 1">
+                        <span *ngIf="phaseDistribution.overall.endgame.percentage > 15" class="text-xs font-bold text-white">
                           {{ phaseDistribution.overall.endgame.percentage | number:'1.0-0' }}%
                         </span>
                       </div>
@@ -265,35 +290,105 @@ import { forkJoin } from 'rxjs';
             </div>
           </div>
 
+          <!-- Tactical Patterns Card -->
+          <div *ngIf="blunderData" class="group rounded-xl sm:rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-xl sm:shadow-2xl hover:shadow-glow-warning hover:border-warning/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-4 sm:p-6 bg-gradient-to-br from-warning/5 to-transparent">
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <div class="p-2 rounded-lg bg-warning/10 group-hover:bg-warning/20 transition-colors duration-300">
+                    <svg class="w-4 h-4 sm:w-5 sm:h-5 text-warning" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 class="text-lg sm:text-xl font-bold leading-none tracking-tight text-gradient">Tactical Patterns</h3>
+                    <p class="text-xs sm:text-sm text-muted-foreground mt-1">Your most common blunder types</p>
+                  </div>
+                </div>
+                <a routerLink="/blunders" class="text-xs sm:text-sm text-primary hover:underline font-medium">View all &rarr;</a>
+              </div>
+            </div>
+            <div class="p-4 sm:p-6 pt-2">
+              <div class="space-y-3 sm:space-y-4">
+                <!-- Overview Stats -->
+                <div class="grid grid-cols-2 gap-2 sm:gap-3 mb-4">
+                  <div class="p-2 sm:p-3 rounded-lg bg-card/50 border border-border/30 text-center">
+                    <div class="text-xl sm:text-2xl font-bold text-warning">{{ blunderData.overview.totalBlunders }}</div>
+                    <div class="text-xs text-muted-foreground">Total Blunders</div>
+                  </div>
+                  <div class="p-2 sm:p-3 rounded-lg bg-card/50 border border-border/30 text-center">
+                    <div class="text-xl sm:text-2xl font-bold text-foreground">{{ blunderData.overview.avgCentipawnLoss }}</div>
+                    <div class="text-xs text-muted-foreground">Avg CP Loss</div>
+                  </div>
+                </div>
+
+                <!-- Top Themes -->
+                <div class="space-y-2">
+                  <h4 class="text-xs sm:text-sm font-semibold text-muted-foreground uppercase tracking-wide">Top Themes</h4>
+                  <div *ngFor="let theme of blunderData.byTheme.slice(0, 4)" class="flex items-center justify-between p-2 rounded-lg bg-muted/20 hover:bg-muted/30 transition-colors">
+                    <div class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full" [ngClass]="getThemeColor(theme.theme)"></span>
+                      <span class="text-xs sm:text-sm font-medium capitalize">{{ formatTheme(theme.theme) }}</span>
+                    </div>
+                    <div class="text-right">
+                      <span class="text-xs sm:text-sm font-bold">{{ theme.count }}</span>
+                      <span class="text-xs text-muted-foreground ml-1">({{ theme.percentage }}%)</span>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Blunders by Phase -->
+                <div class="space-y-2 pt-2 border-t border-border/30">
+                  <h4 class="text-xs sm:text-sm font-semibold text-muted-foreground uppercase tracking-wide">By Phase</h4>
+                  <div class="grid grid-cols-3 gap-2">
+                    <div class="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
+                      <div class="text-sm sm:text-base font-bold text-blue-500">{{ blunderData.byPhase.opening.count }}</div>
+                      <div class="text-xs text-muted-foreground">Opening</div>
+                    </div>
+                    <div class="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center">
+                      <div class="text-sm sm:text-base font-bold text-purple-500">{{ blunderData.byPhase.middlegame.count }}</div>
+                      <div class="text-xs text-muted-foreground">Middle</div>
+                    </div>
+                    <div class="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
+                      <div class="text-sm sm:text-base font-bold text-green-500">{{ blunderData.byPhase.endgame.count }}</div>
+                      <div class="text-xs text-muted-foreground">Endgame</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Opening Performance Card (Full Width) -->
-          <div *ngIf="openingPerformance && openingPerformance.length > 0" class="lg:col-span-2 group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-warning hover:border-warning/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
-            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-warning/5 to-transparent">
+          <div *ngIf="openingPerformance && openingPerformance.length > 0" class="md:col-span-2 group rounded-xl sm:rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-xl sm:shadow-2xl hover:shadow-glow-primary hover:border-primary/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-4 sm:p-6 bg-gradient-to-br from-primary/5 to-transparent">
               <div class="flex items-center gap-3">
-                <div class="p-2 rounded-lg bg-warning/10 group-hover:bg-warning/20 transition-colors duration-300">
-                  <svg class="w-5 h-5 text-warning" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors duration-300">
+                  <svg class="w-4 h-4 sm:w-5 sm:h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
                   </svg>
                 </div>
                 <div>
-                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Opening Performance</h3>
-                  <p class="text-sm text-muted-foreground mt-1">Your most played openings and their success rates</p>
+                  <h3 class="text-lg sm:text-xl font-bold leading-none tracking-tight text-gradient">Opening Performance</h3>
+                  <p class="text-xs sm:text-sm text-muted-foreground mt-1">Your most played openings and their success rates</p>
                 </div>
               </div>
             </div>
-            <div class="p-6 pt-2">
-              <div class="overflow-x-auto">
+            <div class="p-4 sm:p-6 pt-2">
+              <!-- Desktop Table View -->
+              <div class="hidden sm:block overflow-x-auto">
                 <table class="w-full">
                   <thead>
                     <tr class="border-b border-border/30">
                       <th class="text-left py-3 px-4 font-semibold text-muted-foreground text-sm">Opening</th>
                       <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm">Games</th>
                       <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm">Win Rate</th>
-                      <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm hidden sm:table-cell">W/D/L</th>
+                      <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm">W/D/L</th>
                       <th class="text-right py-3 px-4 font-semibold text-muted-foreground text-sm">Performance</th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr *ngFor="let opening of openingPerformance; let i = index"
+                    <tr *ngFor="let opening of openingPerformance"
                         class="border-b border-border/20 hover:bg-muted/20 transition-colors duration-200"
                         [ngClass]="{'bg-success/5': opening.winRate >= 60, 'bg-destructive/5': opening.winRate < 40}">
                       <td class="py-3 px-4">
@@ -311,7 +406,7 @@ import { forkJoin } from 'rxjs';
                           {{ opening.winRate | number:'1.0-0' }}%
                         </span>
                       </td>
-                      <td class="text-center py-3 px-4 hidden sm:table-cell">
+                      <td class="text-center py-3 px-4">
                         <span class="text-success">{{ opening.wins }}</span>
                         <span class="text-muted-foreground">/</span>
                         <span class="text-muted-foreground">{{ opening.draws }}</span>
@@ -332,9 +427,46 @@ import { forkJoin } from 'rxjs';
                 </table>
               </div>
 
+              <!-- Mobile Card View -->
+              <div class="sm:hidden space-y-3">
+                <div *ngFor="let opening of openingPerformance"
+                     class="p-3 rounded-xl border border-border/30 hover:border-primary/30 transition-colors"
+                     [ngClass]="{'bg-success/5 border-success/20': opening.winRate >= 60, 'bg-destructive/5 border-destructive/20': opening.winRate < 40}">
+                  <div class="flex items-start justify-between mb-2">
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span class="text-xs font-mono text-muted-foreground bg-muted/30 px-1.5 py-0.5 rounded">{{ opening.ecoCode }}</span>
+                      </div>
+                      <p class="text-sm font-medium text-foreground truncate" [title]="opening.name">{{ opening.name }}</p>
+                    </div>
+                    <span class="text-xl font-bold ml-2"
+                      [ngClass]="{'text-success': opening.winRate >= 60, 'text-destructive': opening.winRate < 40, 'text-foreground': opening.winRate >= 40 && opening.winRate < 60}">
+                      {{ opening.winRate | number:'1.0-0' }}%
+                    </span>
+                  </div>
+                  <div class="flex items-center justify-between text-xs">
+                    <div class="flex items-center gap-3">
+                      <span class="text-muted-foreground">{{ opening.games }} games</span>
+                      <span>
+                        <span class="text-success font-medium">{{ opening.wins }}W</span>
+                        <span class="text-muted-foreground mx-0.5">/</span>
+                        <span class="text-muted-foreground">{{ opening.draws }}D</span>
+                        <span class="text-muted-foreground mx-0.5">/</span>
+                        <span class="text-destructive font-medium">{{ opening.losses }}L</span>
+                      </span>
+                    </div>
+                  </div>
+                  <div class="mt-2 w-full h-1.5 rounded-full bg-muted/30 overflow-hidden flex">
+                    <div class="h-full bg-success" [style.width.%]="opening.winRate"></div>
+                    <div class="h-full bg-muted-foreground" [style.width.%]="opening.drawRate"></div>
+                    <div class="h-full bg-destructive" [style.width.%]="opening.lossRate"></div>
+                  </div>
+                </div>
+              </div>
+
               <!-- Empty state for no openings -->
               <div *ngIf="openingPerformance.length === 0" class="text-center py-8">
-                <p class="text-muted-foreground">No opening data available yet. Play more games to see your opening statistics.</p>
+                <p class="text-muted-foreground text-sm">No opening data available yet. Play more games to see your opening statistics.</p>
               </div>
             </div>
           </div>
@@ -342,14 +474,14 @@ import { forkJoin } from 'rxjs';
 
         <!-- No Data State -->
         <div *ngIf="!loading && !error && !accuracyByResult && !phaseDistribution && !accuracyByPhase && (!openingPerformance || openingPerformance.length === 0)"
-             class="text-center py-16 animate-fade-in">
-          <div class="p-4 rounded-full bg-muted/30 w-20 h-20 mx-auto mb-4 flex items-center justify-center">
-            <svg class="w-10 h-10 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+             class="text-center py-12 sm:py-16 animate-fade-in">
+          <div class="p-4 rounded-full bg-muted/30 w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-4 flex items-center justify-center">
+            <svg class="w-8 h-8 sm:w-10 sm:h-10 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
             </svg>
           </div>
-          <h3 class="text-xl font-bold text-foreground mb-2">No Insights Available</h3>
-          <p class="text-muted-foreground">Upload and analyze some games to see your chess insights.</p>
+          <h3 class="text-lg sm:text-xl font-bold text-foreground mb-2">No Insights Available</h3>
+          <p class="text-sm text-muted-foreground">Upload and analyze some games to see your chess insights.</p>
         </div>
       </div>
     </app-layout>
@@ -360,6 +492,7 @@ export class InsightsComponent implements OnInit {
   phaseDistribution: PhaseDistributionData | null = null;
   accuracyByPhase: AccuracyByPhaseData | null = null;
   openingPerformance: OpeningPerformanceData[] = [];
+  blunderData: BlunderDashboardData | null = null;
 
   loading = true;
   error: string | null = null;
@@ -386,7 +519,8 @@ export class InsightsComponent implements OnInit {
       accuracyByResult: this.chessApi.getAccuracyByResult(color),
       phaseDistribution: this.chessApi.getPhaseDistribution(color),
       accuracyByPhase: this.chessApi.getAccuracyByPhase(color),
-      openingPerformance: this.chessApi.getOpeningPerformance(10, color)
+      openingPerformance: this.chessApi.getOpeningPerformance(10, color),
+      blunderDashboard: this.chessApi.getBlundersDashboard()
     }).subscribe({
       next: (results) => {
         if (results.accuracyByResult.success) {
@@ -401,6 +535,10 @@ export class InsightsComponent implements OnInit {
         if (results.openingPerformance.success) {
           this.openingPerformance = results.openingPerformance.data;
         }
+        // Blunder dashboard doesn't have the same response wrapper
+        if (results.blunderDashboard) {
+          this.blunderData = results.blunderDashboard as BlunderDashboardData;
+        }
         this.loading = false;
       },
       error: (err) => {
@@ -409,5 +547,23 @@ export class InsightsComponent implements OnInit {
         this.loading = false;
       }
     });
+  }
+
+  formatTheme(theme: string): string {
+    return theme.replace(/_/g, ' ');
+  }
+
+  getThemeColor(theme: string): string {
+    const colors: { [key: string]: string } = {
+      'hanging_piece': 'bg-red-500',
+      'fork': 'bg-orange-500',
+      'pin': 'bg-yellow-500',
+      'skewer': 'bg-purple-500',
+      'discovered_attack': 'bg-blue-500',
+      'back_rank': 'bg-pink-500',
+      'trapped_piece': 'bg-indigo-500',
+      'overloaded_piece': 'bg-teal-500'
+    };
+    return colors[theme] || 'bg-gray-500';
   }
 }

--- a/frontend/src/app/pages/insights/insights.component.ts
+++ b/frontend/src/app/pages/insights/insights.component.ts
@@ -1,0 +1,413 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { LayoutComponent } from '../../components/layout/layout.component';
+import {
+  ChessApiService,
+  AccuracyByResultData,
+  PhaseDistributionData,
+  AccuracyByPhaseData,
+  OpeningPerformanceData
+} from '../../services/chess-api.service';
+import { forkJoin } from 'rxjs';
+
+@Component({
+  selector: 'app-insights',
+  standalone: true,
+  imports: [CommonModule, HttpClientModule, LayoutComponent],
+  template: `
+    <app-layout>
+      <div class="space-y-8 pb-8">
+        <!-- Header Section -->
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 animate-fade-in">
+          <div>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-gradient tracking-tight mb-2">Chess Insights</h1>
+            <p class="text-sm sm:text-base text-muted-foreground">Deep analysis of your playing patterns and performance</p>
+          </div>
+
+          <!-- Color Filter -->
+          <div class="flex gap-2">
+            <button
+              (click)="setColorFilter(null)"
+              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 ' + (colorFilter === null ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              All
+            </button>
+            <button
+              (click)="setColorFilter('white')"
+              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'white' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              <div class="w-3 h-3 rounded-full bg-gradient-to-br from-gray-100 to-gray-300 border border-gray-400"></div>
+              White
+            </button>
+            <button
+              (click)="setColorFilter('black')"
+              [class]="'px-4 py-2 rounded-lg font-medium transition-all duration-300 flex items-center gap-2 ' + (colorFilter === 'black' ? 'bg-primary text-primary-foreground' : 'bg-card border border-border hover:bg-muted')">
+              <div class="w-3 h-3 rounded-full bg-gradient-to-br from-gray-700 to-gray-900"></div>
+              Black
+            </button>
+          </div>
+        </div>
+
+        <!-- Loading State -->
+        <div *ngIf="loading" class="flex flex-col justify-center items-center py-16 animate-fade-in">
+          <div class="relative">
+            <div class="w-16 h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></div>
+            <div class="absolute inset-0 w-16 h-16 border-4 border-transparent border-t-accent rounded-full animate-spin" style="animation-duration: 1.5s;"></div>
+          </div>
+          <p class="text-muted-foreground mt-6 text-sm font-medium">Loading insights...</p>
+        </div>
+
+        <!-- Error State -->
+        <div *ngIf="error" class="rounded-2xl border-2 border-destructive/30 bg-gradient-to-br from-destructive/10 to-destructive/5 p-6 shadow-xl animate-slide-up">
+          <div class="flex items-start gap-4">
+            <div class="flex-shrink-0 p-2 rounded-lg bg-destructive/20">
+              <svg class="w-6 h-6 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+              </svg>
+            </div>
+            <div>
+              <h3 class="text-lg font-bold text-destructive mb-1">Error Loading Insights</h3>
+              <p class="text-sm text-foreground/80">{{ error }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Insights Grid -->
+        <div *ngIf="!loading && !error" class="grid gap-6 lg:grid-cols-2 animate-slide-up">
+
+          <!-- Accuracy by Result Card -->
+          <div *ngIf="accuracyByResult" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-success hover:border-success/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-success/5 to-transparent">
+              <div class="flex items-center gap-3">
+                <div class="p-2 rounded-lg bg-success/10 group-hover:bg-success/20 transition-colors duration-300">
+                  <svg class="w-5 h-5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Result</h3>
+                  <p class="text-sm text-muted-foreground mt-1">How accurately you play in wins vs losses</p>
+                </div>
+              </div>
+            </div>
+            <div class="p-6 pt-2">
+              <div class="space-y-4">
+                <!-- Overall -->
+                <div class="flex items-center justify-between p-3 rounded-lg bg-card/50 border border-border/30">
+                  <span class="font-medium text-foreground">Overall</span>
+                  <div class="text-right">
+                    <span class="text-2xl font-bold text-gradient">{{ accuracyByResult.overall.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.overall.games }} games)</span>
+                  </div>
+                </div>
+                <!-- Wins -->
+                <div class="flex items-center justify-between p-3 rounded-lg bg-success/5 border border-success/20">
+                  <div class="flex items-center gap-2">
+                    <div class="w-2 h-2 rounded-full bg-success"></div>
+                    <span class="font-medium text-success">Wins</span>
+                  </div>
+                  <div class="text-right">
+                    <span class="text-xl font-bold text-success">{{ accuracyByResult.wins.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.wins.games }} games)</span>
+                  </div>
+                </div>
+                <!-- Draws -->
+                <div class="flex items-center justify-between p-3 rounded-lg bg-muted/30 border border-border/30">
+                  <div class="flex items-center gap-2">
+                    <div class="w-2 h-2 rounded-full bg-muted-foreground"></div>
+                    <span class="font-medium text-muted-foreground">Draws</span>
+                  </div>
+                  <div class="text-right">
+                    <span class="text-xl font-bold">{{ accuracyByResult.draws.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.draws.games }} games)</span>
+                  </div>
+                </div>
+                <!-- Losses -->
+                <div class="flex items-center justify-between p-3 rounded-lg bg-destructive/5 border border-destructive/20">
+                  <div class="flex items-center gap-2">
+                    <div class="w-2 h-2 rounded-full bg-destructive"></div>
+                    <span class="font-medium text-destructive">Losses</span>
+                  </div>
+                  <div class="text-right">
+                    <span class="text-xl font-bold text-destructive">{{ accuracyByResult.losses.accuracy | number:'1.1-1' }}%</span>
+                    <span class="text-xs text-muted-foreground ml-2">({{ accuracyByResult.losses.games }} games)</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Accuracy by Phase Card -->
+          <div *ngIf="accuracyByPhase" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-accent hover:border-accent/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-accent/5 to-transparent">
+              <div class="flex items-center gap-3">
+                <div class="p-2 rounded-lg bg-accent/10 group-hover:bg-accent/20 transition-colors duration-300">
+                  <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Accuracy by Phase</h3>
+                  <p class="text-sm text-muted-foreground mt-1">Your accuracy in different game phases</p>
+                </div>
+              </div>
+            </div>
+            <div class="p-6 pt-2">
+              <div class="space-y-4">
+                <!-- Opening -->
+                <div class="space-y-2">
+                  <div class="flex items-center justify-between">
+                    <span class="font-medium text-foreground">Opening</span>
+                    <span class="text-lg font-bold text-chart-1">{{ accuracyByPhase.opening.accuracy | number:'1.1-1' }}%</span>
+                  </div>
+                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                    <div class="h-full bg-gradient-to-r from-chart-1 to-chart-1/80 rounded-full transition-all duration-1000"
+                      [style.width.%]="accuracyByPhase.opening.accuracy"></div>
+                  </div>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.opening.gamesWithData }} games with data</p>
+                </div>
+                <!-- Middlegame -->
+                <div class="space-y-2">
+                  <div class="flex items-center justify-between">
+                    <span class="font-medium text-foreground">Middlegame</span>
+                    <span class="text-lg font-bold text-chart-2">{{ accuracyByPhase.middlegame.accuracy | number:'1.1-1' }}%</span>
+                  </div>
+                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                    <div class="h-full bg-gradient-to-r from-chart-2 to-chart-2/80 rounded-full transition-all duration-1000"
+                      [style.width.%]="accuracyByPhase.middlegame.accuracy"></div>
+                  </div>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.middlegame.gamesWithData }} games with data</p>
+                </div>
+                <!-- Endgame -->
+                <div class="space-y-2">
+                  <div class="flex items-center justify-between">
+                    <span class="font-medium text-foreground">Endgame</span>
+                    <span class="text-lg font-bold text-chart-3">{{ accuracyByPhase.endgame.accuracy | number:'1.1-1' }}%</span>
+                  </div>
+                  <div class="relative h-3 w-full overflow-hidden rounded-full bg-muted/50">
+                    <div class="h-full bg-gradient-to-r from-chart-3 to-chart-3/80 rounded-full transition-all duration-1000"
+                      [style.width.%]="accuracyByPhase.endgame.accuracy"></div>
+                  </div>
+                  <p class="text-xs text-muted-foreground">{{ accuracyByPhase.endgame.gamesWithData }} games with data</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Phase Distribution Card -->
+          <div *ngIf="phaseDistribution" class="group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-primary hover:border-primary/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-primary/5 to-transparent">
+              <div class="flex items-center gap-3">
+                <div class="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors duration-300">
+                  <svg class="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Phase Distribution</h3>
+                  <p class="text-sm text-muted-foreground mt-1">When do your games typically end?</p>
+                </div>
+              </div>
+            </div>
+            <div class="p-6 pt-2">
+              <div class="space-y-4">
+                <p class="text-sm text-muted-foreground text-center mb-4">{{ phaseDistribution.totalGames }} games analyzed</p>
+
+                <!-- Horizontal Bar Chart -->
+                <div class="space-y-3">
+                  <!-- Opening -->
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between text-sm">
+                      <span class="font-medium">Opening</span>
+                      <span class="text-muted-foreground">{{ phaseDistribution.overall.opening.count }} ({{ phaseDistribution.overall.opening.percentage | number:'1.0-0' }}%)</span>
+                    </div>
+                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                      <div class="h-full bg-gradient-to-r from-chart-1 to-chart-1/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
+                        [style.width.%]="phaseDistribution.overall.opening.percentage">
+                        <span *ngIf="phaseDistribution.overall.opening.percentage > 10" class="text-xs font-bold text-white">
+                          {{ phaseDistribution.overall.opening.percentage | number:'1.0-0' }}%
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- Middlegame -->
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between text-sm">
+                      <span class="font-medium">Middlegame</span>
+                      <span class="text-muted-foreground">{{ phaseDistribution.overall.middlegame.count }} ({{ phaseDistribution.overall.middlegame.percentage | number:'1.0-0' }}%)</span>
+                    </div>
+                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                      <div class="h-full bg-gradient-to-r from-chart-2 to-chart-2/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
+                        [style.width.%]="phaseDistribution.overall.middlegame.percentage">
+                        <span *ngIf="phaseDistribution.overall.middlegame.percentage > 10" class="text-xs font-bold text-white">
+                          {{ phaseDistribution.overall.middlegame.percentage | number:'1.0-0' }}%
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- Endgame -->
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between text-sm">
+                      <span class="font-medium">Endgame</span>
+                      <span class="text-muted-foreground">{{ phaseDistribution.overall.endgame.count }} ({{ phaseDistribution.overall.endgame.percentage | number:'1.0-0' }}%)</span>
+                    </div>
+                    <div class="relative h-6 w-full overflow-hidden rounded-lg bg-muted/30">
+                      <div class="h-full bg-gradient-to-r from-chart-3 to-chart-3/60 rounded-lg flex items-center justify-end pr-2 transition-all duration-1000"
+                        [style.width.%]="phaseDistribution.overall.endgame.percentage">
+                        <span *ngIf="phaseDistribution.overall.endgame.percentage > 10" class="text-xs font-bold text-white">
+                          {{ phaseDistribution.overall.endgame.percentage | number:'1.0-0' }}%
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Opening Performance Card (Full Width) -->
+          <div *ngIf="openingPerformance && openingPerformance.length > 0" class="lg:col-span-2 group rounded-2xl border-2 border-border/30 gradient-card text-card-foreground shadow-2xl hover:shadow-glow-warning hover:border-warning/50 transition-all duration-500 backdrop-blur-sm overflow-hidden">
+            <div class="flex flex-col space-y-2 p-6 bg-gradient-to-br from-warning/5 to-transparent">
+              <div class="flex items-center gap-3">
+                <div class="p-2 rounded-lg bg-warning/10 group-hover:bg-warning/20 transition-colors duration-300">
+                  <svg class="w-5 h-5 text-warning" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-xl font-bold leading-none tracking-tight text-gradient">Opening Performance</h3>
+                  <p class="text-sm text-muted-foreground mt-1">Your most played openings and their success rates</p>
+                </div>
+              </div>
+            </div>
+            <div class="p-6 pt-2">
+              <div class="overflow-x-auto">
+                <table class="w-full">
+                  <thead>
+                    <tr class="border-b border-border/30">
+                      <th class="text-left py-3 px-4 font-semibold text-muted-foreground text-sm">Opening</th>
+                      <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm">Games</th>
+                      <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm">Win Rate</th>
+                      <th class="text-center py-3 px-4 font-semibold text-muted-foreground text-sm hidden sm:table-cell">W/D/L</th>
+                      <th class="text-right py-3 px-4 font-semibold text-muted-foreground text-sm">Performance</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr *ngFor="let opening of openingPerformance; let i = index"
+                        class="border-b border-border/20 hover:bg-muted/20 transition-colors duration-200"
+                        [ngClass]="{'bg-success/5': opening.winRate >= 60, 'bg-destructive/5': opening.winRate < 40}">
+                      <td class="py-3 px-4">
+                        <div class="flex items-center gap-2">
+                          <span class="text-xs font-mono text-muted-foreground bg-muted/30 px-2 py-0.5 rounded">{{ opening.ecoCode }}</span>
+                          <span class="font-medium text-foreground truncate max-w-[200px]" [title]="opening.name">{{ opening.name }}</span>
+                        </div>
+                      </td>
+                      <td class="text-center py-3 px-4">
+                        <span class="font-semibold">{{ opening.games }}</span>
+                      </td>
+                      <td class="text-center py-3 px-4">
+                        <span class="font-bold text-lg"
+                          [ngClass]="{'text-success': opening.winRate >= 60, 'text-destructive': opening.winRate < 40, 'text-foreground': opening.winRate >= 40 && opening.winRate < 60}">
+                          {{ opening.winRate | number:'1.0-0' }}%
+                        </span>
+                      </td>
+                      <td class="text-center py-3 px-4 hidden sm:table-cell">
+                        <span class="text-success">{{ opening.wins }}</span>
+                        <span class="text-muted-foreground">/</span>
+                        <span class="text-muted-foreground">{{ opening.draws }}</span>
+                        <span class="text-muted-foreground">/</span>
+                        <span class="text-destructive">{{ opening.losses }}</span>
+                      </td>
+                      <td class="py-3 px-4">
+                        <div class="flex items-center justify-end gap-1">
+                          <div class="w-24 h-2 rounded-full bg-muted/30 overflow-hidden flex">
+                            <div class="h-full bg-success" [style.width.%]="opening.winRate"></div>
+                            <div class="h-full bg-muted-foreground" [style.width.%]="opening.drawRate"></div>
+                            <div class="h-full bg-destructive" [style.width.%]="opening.lossRate"></div>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <!-- Empty state for no openings -->
+              <div *ngIf="openingPerformance.length === 0" class="text-center py-8">
+                <p class="text-muted-foreground">No opening data available yet. Play more games to see your opening statistics.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- No Data State -->
+        <div *ngIf="!loading && !error && !accuracyByResult && !phaseDistribution && !accuracyByPhase && (!openingPerformance || openingPerformance.length === 0)"
+             class="text-center py-16 animate-fade-in">
+          <div class="p-4 rounded-full bg-muted/30 w-20 h-20 mx-auto mb-4 flex items-center justify-center">
+            <svg class="w-10 h-10 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+            </svg>
+          </div>
+          <h3 class="text-xl font-bold text-foreground mb-2">No Insights Available</h3>
+          <p class="text-muted-foreground">Upload and analyze some games to see your chess insights.</p>
+        </div>
+      </div>
+    </app-layout>
+  `
+})
+export class InsightsComponent implements OnInit {
+  accuracyByResult: AccuracyByResultData | null = null;
+  phaseDistribution: PhaseDistributionData | null = null;
+  accuracyByPhase: AccuracyByPhaseData | null = null;
+  openingPerformance: OpeningPerformanceData[] = [];
+
+  loading = true;
+  error: string | null = null;
+  colorFilter: 'white' | 'black' | null = null;
+
+  constructor(private chessApi: ChessApiService) {}
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  setColorFilter(color: 'white' | 'black' | null) {
+    this.colorFilter = color;
+    this.loadData();
+  }
+
+  loadData() {
+    this.loading = true;
+    this.error = null;
+
+    const color = this.colorFilter || undefined;
+
+    forkJoin({
+      accuracyByResult: this.chessApi.getAccuracyByResult(color),
+      phaseDistribution: this.chessApi.getPhaseDistribution(color),
+      accuracyByPhase: this.chessApi.getAccuracyByPhase(color),
+      openingPerformance: this.chessApi.getOpeningPerformance(10, color)
+    }).subscribe({
+      next: (results) => {
+        if (results.accuracyByResult.success) {
+          this.accuracyByResult = results.accuracyByResult.data;
+        }
+        if (results.phaseDistribution.success) {
+          this.phaseDistribution = results.phaseDistribution.data;
+        }
+        if (results.accuracyByPhase.success) {
+          this.accuracyByPhase = results.accuracyByPhase.data;
+        }
+        if (results.openingPerformance.success) {
+          this.openingPerformance = results.openingPerformance.data;
+        }
+        this.loading = false;
+      },
+      error: (err) => {
+        console.error('Error loading insights:', err);
+        this.error = err.message || 'Failed to load insights data';
+        this.loading = false;
+      }
+    });
+  }
+}

--- a/frontend/src/app/services/chess-api.service.ts
+++ b/frontend/src/app/services/chess-api.service.ts
@@ -36,6 +36,48 @@ export interface PerformanceData {
   }>;
 }
 
+// Chess.com Insights Dashboard Interfaces (ADR 009)
+export interface AccuracyByResultData {
+  overall: { accuracy: number; games: number; avgCentipawnLoss?: number };
+  wins: { accuracy: number; games: number; avgCentipawnLoss?: number };
+  draws: { accuracy: number; games: number; avgCentipawnLoss?: number };
+  losses: { accuracy: number; games: number; avgCentipawnLoss?: number };
+}
+
+export interface PhaseDistributionData {
+  overall: {
+    opening: { count: number; percentage: number };
+    middlegame: { count: number; percentage: number };
+    endgame: { count: number; percentage: number };
+  };
+  totalGames: number;
+}
+
+export interface AccuracyByPhaseData {
+  opening: { accuracy: number; gamesWithData: number; avgCentipawnLoss?: number };
+  middlegame: { accuracy: number; gamesWithData: number; avgCentipawnLoss?: number };
+  endgame: { accuracy: number; gamesWithData: number; avgCentipawnLoss?: number };
+  totalGames: number;
+}
+
+export interface OpeningPerformanceData {
+  ecoCode: string;
+  name: string;
+  games: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  winRate: number;
+  drawRate: number;
+  lossRate: number;
+}
+
+export interface InsightsApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })

--- a/frontend/src/app/services/chess-api.service.ts
+++ b/frontend/src/app/services/chess-api.service.ts
@@ -183,4 +183,61 @@ export class ChessApiService {
     if (endDate) params.endDate = endDate;
     return this.http.get(`${this.baseUrl}/blunders/timeline`, { params });
   }
+
+  // ============================================
+  // Chess.com Insights Dashboard API (ADR 009)
+  // ============================================
+
+  /**
+   * Get accuracy breakdown by game result (win/draw/loss)
+   * @param color Optional filter by player color
+   */
+  getAccuracyByResult(color?: 'white' | 'black'): Observable<InsightsApiResponse<AccuracyByResultData>> {
+    const params: any = {};
+    if (color) params.color = color;
+    return this.http.get<InsightsApiResponse<AccuracyByResultData>>(
+      `${this.baseUrl}/insights/accuracy`,
+      { params }
+    );
+  }
+
+  /**
+   * Get distribution of which game phase games typically end in
+   * @param color Optional filter by player color
+   */
+  getPhaseDistribution(color?: 'white' | 'black'): Observable<InsightsApiResponse<PhaseDistributionData>> {
+    const params: any = {};
+    if (color) params.color = color;
+    return this.http.get<InsightsApiResponse<PhaseDistributionData>>(
+      `${this.baseUrl}/insights/phases`,
+      { params }
+    );
+  }
+
+  /**
+   * Get aggregate accuracy by game phase across all games
+   * @param color Optional filter by player color
+   */
+  getAccuracyByPhase(color?: 'white' | 'black'): Observable<InsightsApiResponse<AccuracyByPhaseData>> {
+    const params: any = {};
+    if (color) params.color = color;
+    return this.http.get<InsightsApiResponse<AccuracyByPhaseData>>(
+      `${this.baseUrl}/insights/accuracy-by-phase`,
+      { params }
+    );
+  }
+
+  /**
+   * Get performance statistics for most frequently played openings
+   * @param limit Number of openings to return (default: 10)
+   * @param color Optional filter by player color
+   */
+  getOpeningPerformance(limit: number = 10, color?: 'white' | 'black'): Observable<InsightsApiResponse<OpeningPerformanceData[]>> {
+    const params: any = { limit: limit.toString() };
+    if (color) params.color = color;
+    return this.http.get<InsightsApiResponse<OpeningPerformanceData[]>>(
+      `${this.baseUrl}/insights/openings`,
+      { params }
+    );
+  }
 }

--- a/src/api/controllers/dashboard.controller.js
+++ b/src/api/controllers/dashboard.controller.js
@@ -145,6 +145,109 @@ class DashboardController {
       res.json([]);
     }
   }
+
+  // ============================================
+  // Chess.com Insights Dashboard Endpoints (ADR 009)
+  // ============================================
+
+  /**
+   * GET /api/insights/accuracy
+   * Get accuracy breakdown by game result (win/draw/loss)
+   * Query params: color (optional) - 'white' or 'black'
+   */
+  async getAccuracyByResult(req, res) {
+    try {
+      const color = req.query.color || null;
+      console.log(`📊 [INSIGHTS]: Accuracy by result requested${color ? ` for ${color}` : ''}`);
+
+      const result = await this.dashboardService.getAccuracyByResult(req.userId, color);
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      console.error('Accuracy by result API error:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message || 'Failed to get accuracy by result'
+      });
+    }
+  }
+
+  /**
+   * GET /api/insights/phases
+   * Get distribution of which game phase games typically end in
+   * Query params: color (optional) - 'white' or 'black'
+   */
+  async getPhaseDistribution(req, res) {
+    try {
+      const color = req.query.color || null;
+      console.log(`📊 [INSIGHTS]: Phase distribution requested${color ? ` for ${color}` : ''}`);
+
+      const result = await this.dashboardService.getPhaseDistribution(req.userId, color);
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      console.error('Phase distribution API error:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message || 'Failed to get phase distribution'
+      });
+    }
+  }
+
+  /**
+   * GET /api/insights/accuracy-by-phase
+   * Get aggregate accuracy by game phase across all games
+   * Query params: color (optional) - 'white' or 'black'
+   */
+  async getAccuracyByPhase(req, res) {
+    try {
+      const color = req.query.color || null;
+      console.log(`📊 [INSIGHTS]: Accuracy by phase requested${color ? ` for ${color}` : ''}`);
+
+      const result = await this.dashboardService.getAccuracyByPhase(req.userId, color);
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      console.error('Accuracy by phase API error:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message || 'Failed to get accuracy by phase'
+      });
+    }
+  }
+
+  /**
+   * GET /api/insights/openings
+   * Get performance statistics for most frequently played openings
+   * Query params:
+   *   - limit (optional, default: 10) - number of openings to return
+   *   - color (optional) - 'white' or 'black'
+   */
+  async getOpeningPerformance(req, res) {
+    try {
+      const limit = req.query.limit ? parseInt(req.query.limit) : 10;
+      const color = req.query.color || null;
+      console.log(`📊 [INSIGHTS]: Opening performance requested (limit: ${limit}${color ? `, color: ${color}` : ''})`);
+
+      const result = await this.dashboardService.getOpeningPerformance(req.userId, limit, color);
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      console.error('Opening performance API error:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message || 'Failed to get opening performance'
+      });
+    }
+  }
 }
 
 module.exports = new DashboardController();

--- a/src/api/routes/dashboard.routes.js
+++ b/src/api/routes/dashboard.routes.js
@@ -23,4 +23,12 @@ router.get('/heatmap-db', dashboardController.getHeatmap.bind(dashboardControlle
 // Games list
 router.get('/games', dashboardController.getGamesList.bind(dashboardController));
 
+// ============================================
+// Chess.com Insights Dashboard (ADR 009)
+// ============================================
+router.get('/insights/accuracy', dashboardController.getAccuracyByResult.bind(dashboardController));
+router.get('/insights/phases', dashboardController.getPhaseDistribution.bind(dashboardController));
+router.get('/insights/accuracy-by-phase', dashboardController.getAccuracyByPhase.bind(dashboardController));
+router.get('/insights/openings', dashboardController.getOpeningPerformance.bind(dashboardController));
+
 module.exports = router;

--- a/tests/services/DashboardService.test.js
+++ b/tests/services/DashboardService.test.js
@@ -92,4 +92,359 @@ describe('DashboardService', () => {
       });
     });
   });
+
+  // ============================================
+  // Chess.com Insights Dashboard Methods (ADR 009)
+  // ============================================
+
+  describe('getAccuracyByResult', () => {
+    it('should return empty stats when no games exist', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      const result = await dashboardService.getAccuracyByResult('user123');
+
+      expect(result).toEqual({
+        overall: { accuracy: 0, games: 0 },
+        wins: { accuracy: 0, games: 0 },
+        draws: { accuracy: 0, games: 0 },
+        losses: { accuracy: 0, games: 0 }
+      });
+    });
+
+    it('should categorize games by result correctly', async () => {
+      const mockGames = [
+        { id: 1, result: '1-0', user_color: 'white' },  // Win
+        { id: 2, result: '0-1', user_color: 'white' },  // Loss
+        { id: 3, result: '1/2-1/2', user_color: 'white' },  // Draw
+        { id: 4, result: '0-1', user_color: 'black' }   // Win (black won)
+      ];
+
+      const mockAnalysis = [
+        { move_number: 1, centipawn_loss: 20 },
+        { move_number: 3, centipawn_loss: 30 }
+      ];
+
+      mockDatabase.all
+        .mockResolvedValueOnce(mockGames)  // First call: get games
+        .mockResolvedValue(mockAnalysis);   // Subsequent calls: get analysis
+
+      const result = await dashboardService.getAccuracyByResult('user123');
+
+      expect(result.wins.games).toBe(2);  // Game 1 (white won) + Game 4 (black won)
+      expect(result.losses.games).toBe(1);  // Game 2
+      expect(result.draws.games).toBe(1);   // Game 3
+      expect(result.overall.games).toBe(4);
+    });
+
+    it('should filter by color when provided', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      await dashboardService.getAccuracyByResult('user123', 'white');
+
+      const query = mockDatabase.all.mock.calls[0][0];
+      const params = mockDatabase.all.mock.calls[0][1];
+
+      expect(query).toContain('user_color = ?');
+      expect(params).toContain('white');
+    });
+
+    it('should calculate accuracy from centipawn loss', async () => {
+      const mockGames = [
+        { id: 1, result: '1-0', user_color: 'white' }
+      ];
+
+      // Low CPL = high accuracy
+      const mockAnalysis = [
+        { move_number: 1, centipawn_loss: 10 },
+        { move_number: 3, centipawn_loss: 20 },
+        { move_number: 5, centipawn_loss: 15 }
+      ];
+
+      mockDatabase.all
+        .mockResolvedValueOnce(mockGames)
+        .mockResolvedValue(mockAnalysis);
+
+      const result = await dashboardService.getAccuracyByResult('user123');
+
+      // Average CPL = (10 + 20 + 15) / 3 = 15
+      // Accuracy = 100 - (15 / 3) = 95
+      expect(result.wins.accuracy).toBe(95);
+      expect(result.wins.avgCentipawnLoss).toBe(15);
+    });
+  });
+
+  describe('getPhaseDistribution', () => {
+    it('should return empty stats when no games exist', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      const result = await dashboardService.getPhaseDistribution('user123');
+
+      expect(result).toEqual({
+        overall: {
+          opening: { count: 0, percentage: 0 },
+          middlegame: { count: 0, percentage: 0 },
+          endgame: { count: 0, percentage: 0 }
+        },
+        totalGames: 0
+      });
+    });
+
+    it('should classify games ending in opening phase (moves 1-10)', async () => {
+      const mockGames = [
+        { id: 1, moves_count: 16, user_color: 'white' },  // 8 full moves -> opening
+        { id: 2, moves_count: 20, user_color: 'white' }   // 10 full moves -> opening
+      ];
+
+      mockDatabase.all.mockResolvedValue(mockGames);
+
+      const result = await dashboardService.getPhaseDistribution('user123');
+
+      expect(result.overall.opening.count).toBe(2);
+      expect(result.overall.opening.percentage).toBe(100);
+      expect(result.overall.middlegame.count).toBe(0);
+      expect(result.overall.endgame.count).toBe(0);
+    });
+
+    it('should classify games ending in middlegame phase (moves 11-30)', async () => {
+      const mockGames = [
+        { id: 1, moves_count: 40, user_color: 'white' },  // 20 full moves -> middlegame
+        { id: 2, moves_count: 50, user_color: 'white' }   // 25 full moves -> middlegame
+      ];
+
+      mockDatabase.all.mockResolvedValue(mockGames);
+
+      const result = await dashboardService.getPhaseDistribution('user123');
+
+      expect(result.overall.middlegame.count).toBe(2);
+      expect(result.overall.middlegame.percentage).toBe(100);
+    });
+
+    it('should classify games ending in endgame phase (moves 31+)', async () => {
+      const mockGames = [
+        { id: 1, moves_count: 80, user_color: 'white' },  // 40 full moves -> endgame
+        { id: 2, moves_count: 100, user_color: 'white' }  // 50 full moves -> endgame
+      ];
+
+      mockDatabase.all.mockResolvedValue(mockGames);
+
+      const result = await dashboardService.getPhaseDistribution('user123');
+
+      expect(result.overall.endgame.count).toBe(2);
+      expect(result.overall.endgame.percentage).toBe(100);
+    });
+
+    it('should calculate correct percentages for mixed phases', async () => {
+      const mockGames = [
+        { id: 1, moves_count: 16, user_color: 'white' },   // opening
+        { id: 2, moves_count: 40, user_color: 'white' },   // middlegame
+        { id: 3, moves_count: 80, user_color: 'white' },   // endgame
+        { id: 4, moves_count: 80, user_color: 'white' }    // endgame
+      ];
+
+      mockDatabase.all.mockResolvedValue(mockGames);
+
+      const result = await dashboardService.getPhaseDistribution('user123');
+
+      expect(result.overall.opening.count).toBe(1);
+      expect(result.overall.opening.percentage).toBe(25);
+      expect(result.overall.middlegame.count).toBe(1);
+      expect(result.overall.middlegame.percentage).toBe(25);
+      expect(result.overall.endgame.count).toBe(2);
+      expect(result.overall.endgame.percentage).toBe(50);
+      expect(result.totalGames).toBe(4);
+    });
+
+    it('should filter by color when provided', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      await dashboardService.getPhaseDistribution('user123', 'black');
+
+      const query = mockDatabase.all.mock.calls[0][0];
+      const params = mockDatabase.all.mock.calls[0][1];
+
+      expect(query).toContain('user_color = ?');
+      expect(params).toContain('black');
+    });
+  });
+
+  describe('getAccuracyByPhase', () => {
+    it('should return empty stats when no games exist', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      const result = await dashboardService.getAccuracyByPhase('user123');
+
+      expect(result).toEqual({
+        opening: { accuracy: 0, gamesWithData: 0 },
+        middlegame: { accuracy: 0, gamesWithData: 0 },
+        endgame: { accuracy: 0, gamesWithData: 0 },
+        totalGames: 0
+      });
+    });
+
+    it('should use pre-computed phase_stats when available', async () => {
+      const mockPhaseStats = [
+        { game_id: 1, opening_accuracy: 90, middlegame_accuracy: 80, endgame_accuracy: 70, user_color: 'white' },
+        { game_id: 2, opening_accuracy: 85, middlegame_accuracy: 75, endgame_accuracy: 65, user_color: 'white' }
+      ];
+
+      mockDatabase.all.mockResolvedValueOnce(mockPhaseStats);
+
+      const result = await dashboardService.getAccuracyByPhase('user123');
+
+      expect(result.opening.accuracy).toBe(88);  // (90 + 85) / 2 = 87.5, rounded to 88
+      expect(result.middlegame.accuracy).toBe(78);  // (80 + 75) / 2 = 77.5, rounded to 78
+      expect(result.endgame.accuracy).toBe(68);  // (70 + 65) / 2 = 67.5, rounded to 68
+      expect(result.opening.gamesWithData).toBe(2);
+      expect(result.totalGames).toBe(2);
+    });
+
+    it('should fall back to raw analysis when phase_stats is empty', async () => {
+      // First call returns empty phase_stats
+      mockDatabase.all.mockResolvedValueOnce([]);
+
+      // Second call returns games
+      const mockGames = [
+        { id: 1, user_color: 'white' }
+      ];
+      mockDatabase.all.mockResolvedValueOnce(mockGames);
+
+      // Third call returns analysis
+      const mockAnalysis = [
+        { move_number: 1, centipawn_loss: 10 },   // Opening (move 1)
+        { move_number: 3, centipawn_loss: 15 },   // Opening (move 2)
+        { move_number: 21, centipawn_loss: 25 },  // Middlegame (move 11)
+        { move_number: 61, centipawn_loss: 30 }   // Endgame (move 31)
+      ];
+      mockDatabase.all.mockResolvedValueOnce(mockAnalysis);
+
+      const result = await dashboardService.getAccuracyByPhase('user123');
+
+      expect(result.opening.gamesWithData).toBe(1);
+      expect(result.middlegame.gamesWithData).toBe(1);
+      expect(result.endgame.gamesWithData).toBe(1);
+      expect(result.totalGames).toBe(1);
+    });
+
+    it('should filter by color when provided', async () => {
+      mockDatabase.all.mockResolvedValue([]);
+
+      await dashboardService.getAccuracyByPhase('user123', 'white');
+
+      const query = mockDatabase.all.mock.calls[0][0];
+      const params = mockDatabase.all.mock.calls[0][1];
+
+      expect(query).toContain('user_color = ?');
+      expect(params).toContain('white');
+    });
+  });
+
+  describe('getOpeningPerformance', () => {
+    it('should return empty array when no games exist', async () => {
+      mockDatabase.all
+        .mockResolvedValueOnce([])  // opening_analysis query
+        .mockResolvedValueOnce([]); // fallback PGN query
+
+      const result = await dashboardService.getOpeningPerformance('user123');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should aggregate opening stats correctly', async () => {
+      const mockOpeningGames = [
+        { eco_code: 'C42', opening_name: 'Russian Game', result: '1-0', user_color: 'white', game_id: 1 },
+        { eco_code: 'C42', opening_name: 'Russian Game', result: '0-1', user_color: 'white', game_id: 2 },
+        { eco_code: 'C42', opening_name: 'Russian Game', result: '1/2-1/2', user_color: 'white', game_id: 3 },
+        { eco_code: 'B20', opening_name: 'Sicilian Defense', result: '1-0', user_color: 'white', game_id: 4 }
+      ];
+
+      mockDatabase.all.mockResolvedValueOnce(mockOpeningGames);
+
+      const result = await dashboardService.getOpeningPerformance('user123');
+
+      expect(result).toHaveLength(2);
+
+      const russian = result.find(o => o.ecoCode === 'C42');
+      expect(russian.games).toBe(3);
+      expect(russian.wins).toBe(1);
+      expect(russian.losses).toBe(1);
+      expect(russian.draws).toBe(1);
+      expect(russian.winRate).toBe(33);
+      expect(russian.drawRate).toBe(33);
+      expect(russian.lossRate).toBe(33);
+
+      const sicilian = result.find(o => o.ecoCode === 'B20');
+      expect(sicilian.games).toBe(1);
+      expect(sicilian.wins).toBe(1);
+      expect(sicilian.winRate).toBe(100);
+    });
+
+    it('should sort by games played and respect limit', async () => {
+      const mockOpeningGames = [
+        { eco_code: 'A00', opening_name: 'Opening A', result: '1-0', user_color: 'white', game_id: 1 },
+        { eco_code: 'B00', opening_name: 'Opening B', result: '1-0', user_color: 'white', game_id: 2 },
+        { eco_code: 'B00', opening_name: 'Opening B', result: '1-0', user_color: 'white', game_id: 3 },
+        { eco_code: 'C00', opening_name: 'Opening C', result: '1-0', user_color: 'white', game_id: 4 },
+        { eco_code: 'C00', opening_name: 'Opening C', result: '1-0', user_color: 'white', game_id: 5 },
+        { eco_code: 'C00', opening_name: 'Opening C', result: '1-0', user_color: 'white', game_id: 6 }
+      ];
+
+      mockDatabase.all.mockResolvedValueOnce(mockOpeningGames);
+
+      const result = await dashboardService.getOpeningPerformance('user123', 2);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].ecoCode).toBe('C00');  // 3 games
+      expect(result[1].ecoCode).toBe('B00');  // 2 games
+    });
+
+    it('should handle black wins correctly', async () => {
+      const mockOpeningGames = [
+        { eco_code: 'C42', opening_name: 'Russian Game', result: '0-1', user_color: 'black', game_id: 1 }
+      ];
+
+      mockDatabase.all.mockResolvedValueOnce(mockOpeningGames);
+
+      const result = await dashboardService.getOpeningPerformance('user123');
+
+      expect(result[0].wins).toBe(1);
+      expect(result[0].winRate).toBe(100);
+    });
+
+    it('should filter by color when provided', async () => {
+      mockDatabase.all.mockResolvedValueOnce([]);
+      mockDatabase.all.mockResolvedValueOnce([]);
+
+      await dashboardService.getOpeningPerformance('user123', 10, 'white');
+
+      const query = mockDatabase.all.mock.calls[0][0];
+      const params = mockDatabase.all.mock.calls[0][1];
+
+      expect(query).toContain('user_color = ?');
+      expect(params).toContain('white');
+    });
+
+    it('should fall back to PGN detection when opening_analysis is empty', async () => {
+      // First call: empty opening_analysis
+      mockDatabase.all.mockResolvedValueOnce([]);
+
+      // Second call: games with PGN content
+      const mockGamesWithPGN = [
+        {
+          id: 1,
+          pgn_content: '[ECO "C42"]\n1. e4 e5',
+          result: '1-0',
+          user_color: 'white'
+        }
+      ];
+      mockDatabase.all.mockResolvedValueOnce(mockGamesWithPGN);
+
+      // Mock getOpeningName
+      mockDatabase.get.mockResolvedValueOnce({ opening_name: 'Russian Game' });
+
+      const result = await dashboardService.getOpeningPerformance('user123');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].ecoCode).toBe('C42');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements Chess.com-style Insights Dashboard as specified in ADR 009 and GitHub Issue #100.

**Completed Phases:**
- ✅ Phase 1: Backend service methods (4 new aggregation methods)
- ✅ Phase 2: API endpoints (4 new `/api/insights/*` routes)
- ✅ Phase 3: Frontend Insights page with 5 insight cards

## Features Implemented

| Chess.com Feature | Issue #100 Image | Status |
|-------------------|------------------|--------|
| Accuracy by Result | Image 1 | ✅ |
| Phase Distribution | Image 2 | ✅ |
| Accuracy by Phase | Image 3 | ✅ |
| Opening Performance | Image 4 | ✅ |
| Tactical Patterns Summary | - | ✅ (reuses blunders API) |

## Changes

### Backend (Phase 1 & 2)
- **DashboardService.js**: Added 4 new methods:
  - `getAccuracyByResult()` - Accuracy breakdown by win/draw/loss
  - `getPhaseDistribution()` - Where games typically end
  - `getAccuracyByPhase()` - Accuracy in opening/middlegame/endgame
  - `getOpeningPerformance()` - Top 10 openings with W/D/L stats

- **dashboard.controller.js**: Added 4 controller methods
- **dashboard.routes.js**: Added 4 routes:
  - `GET /api/insights/accuracy`
  - `GET /api/insights/phases`
  - `GET /api/insights/accuracy-by-phase`
  - `GET /api/insights/openings`

### Frontend (Phase 3)
- **New `/insights` page** with:
  - Accuracy by Result card (color-coded win/draw/loss)
  - Accuracy by Phase card (progress bars)
  - Phase Distribution card (horizontal bar chart)
  - Opening Performance table (responsive: table on desktop, cards on mobile)
  - Tactical Patterns card (reuses `/api/blunders/dashboard`)
  - Color filter (All/White/Black)

- **Navigation**: Added Insights link to desktop and mobile layouts

### Tests
- 22 new DashboardService unit tests
- 12 new controller tests
- All 110+ tests passing

### Documentation
- Updated ADR 009 with:
  - Phases 1-3 marked complete
  - Phase 5 implementation plan for remaining features
  - Screenshot references from Issue #100

## Screenshots

The Insights page implements chess.com-style cards as shown in Issue #100 Images 1-4.

## Phase 5 (Future Work)

Remaining features documented in ADR 009 for a separate branch:
- Found vs Missed Tactics (forks/pins) - Images 5-8
- Hanging Pieces by Type - Image 9
- Free Pieces (opponent blunders) - Image 10

## Test Plan

- [x] Backend unit tests pass (22 new tests)
- [x] Controller tests pass (12 new tests)
- [x] Frontend builds successfully
- [ ] Manual testing of Insights page
- [ ] Verify color filter works correctly
- [ ] Test responsive design on mobile

Closes #100 (partial - Phases 1-3 complete, Phase 5 planned)

🤖 Generated with [Claude Code](https://claude.ai/code)